### PR TITLE
Fix issue preventing users from editing reconciliation data

### DIFF
--- a/client/src/pages/BLReconciliation.tsx
+++ b/client/src/pages/BLReconciliation.tsx
@@ -694,10 +694,11 @@ export default function BLReconciliation() {
       </Tabs>
 
       {/* Modal de rapprochement */}
-      {isModalOpen && selectedDelivery && (
+      {selectedDelivery && (
         <ReconciliationModal
+          isOpen={isModalOpen}
           delivery={selectedDelivery}
-          onSave={handleSaveReconciliation}
+          onSave={() => handleSaveReconciliation(selectedDelivery)}
           onClose={handleCloseModal}
         />
       )}


### PR DESCRIPTION
Adjusted ReconciliationModal to correctly display and handle edit modal opening when the edit icon is clicked, resolving a bug where the modal would not appear.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: b163d4c0-de5e-4f4e-a9c0-aed4c7049718
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/b163d4c0-de5e-4f4e-a9c0-aed4c7049718/wlAjxK8