### PR TITLE
Refine reconciliation view by removing manual title and aligning data

### DIFF
--- a/client/src/pages/BLReconciliation.tsx
+++ b/client/src/pages/BLReconciliation.tsx
@@ -78,27 +78,6 @@ export default function BLReconciliation() {
     enabled: !!user
   });
 
-  // Debug : afficher les données récupérées
-  console.log('🔍 BL Reconciliation Debug:', {
-    totalDeliveries: deliveriesWithBL.length,
-    totalSuppliers: suppliers.length,
-    selectedStoreId,
-    userRole: user?.role,
-    deliveries: deliveriesWithBL.map(d => ({
-      id: d.id,
-      supplier: d.supplier?.name,
-      supplierId: d.supplierId,
-      status: d.status,
-      blNumber: d.blNumber,
-      reconciled: d.reconciled
-    })),
-    suppliers: suppliers.map(s => ({
-      id: s.id,
-      name: s.name,
-      isAutoReconciliation: s.isAutoReconciliation
-    }))
-  });
-
   // Séparer les livraisons par mode de rapprochement
   const manualReconciliationDeliveries = deliveriesWithBL.filter((delivery: any) => {
     const supplier = suppliers.find(s => s.id === delivery.supplierId);
@@ -348,13 +327,7 @@ export default function BLReconciliation() {
             </div>
           ) : (
             <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Edit className="w-5 h-5" />
-                  Rapprochements Manuels
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
+              <CardContent className="pt-6">
                 {/* Pagination du haut */}
                 <Pagination
                   currentPage={manualCurrentPage}
@@ -389,7 +362,7 @@ export default function BLReconciliation() {
                           <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                             Montant Fact.
                           </th>
-                          <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          <th className="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                             Écart
                           </th>
                           <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -420,7 +393,11 @@ export default function BLReconciliation() {
                               </div>
                             </td>
                             <td className="px-3 py-2 text-sm">
-                              <div className="text-gray-900">
+                              <div className={`${
+                                delivery.reconciled !== true 
+                                  ? 'font-bold text-gray-900' 
+                                  : 'text-gray-900'
+                              }`}>
                                 {delivery.blNumber || (
                                   <span className="text-gray-400 italic text-xs">Non renseigné</span>
                                 )}
@@ -454,7 +431,7 @@ export default function BLReconciliation() {
                                 }
                               </div>
                             </td>
-                            <td className="px-3 py-2 text-sm">
+                            <td className="px-3 py-2 text-sm text-right">
                               {(() => {
                                 const blAmount = delivery.blAmount ? parseFloat(delivery.blAmount) : 0;
                                 const invoiceAmount = delivery.invoiceAmount ? parseFloat(delivery.invoiceAmount) : 0;


### PR DESCRIPTION
Remove "Rapprochements Manuels" title and icon from the reconciliation view, bold BL numbers for unvalidated lines, and right-align the discrepancy column.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: b163d4c0-de5e-4f4e-a9c0-aed4c7049718
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/b163d4c0-de5e-4f4e-a9c0-aed4c7049718/l9FV9ZH