### PR TITLE
Update reconciliation logic to correctly filter deliveries

### DIFF
--- a/client/src/pages/BLReconciliation.tsx
+++ b/client/src/pages/BLReconciliation.tsx
@@ -81,12 +81,12 @@ export default function BLReconciliation() {
   // Séparer les livraisons par mode de rapprochement
   const manualReconciliationDeliveries = deliveriesWithBL.filter((delivery: any) => {
     const supplier = suppliers.find(s => s.id === delivery.supplierId);
-    return supplier?.isAutoReconciliation !== true;
+    return supplier?.automaticReconciliation !== true;
   });
 
   const automaticReconciliationDeliveries = deliveriesWithBL.filter((delivery: any) => {
     const supplier = suppliers.find(s => s.id === delivery.supplierId);
-    return supplier?.isAutoReconciliation === true;
+    return supplier?.automaticReconciliation === true;
   });
 
   // Fonctions de gestion


### PR DESCRIPTION
Adjusted `isAutoReconciliation` to `automaticReconciliation` in BLReconciliation.tsx for accurate delivery filtering based on supplier reconciliation settings.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: b163d4c0-de5e-4f4e-a9c0-aed4c7049718
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/b163d4c0-de5e-4f4e-a9c0-aed4c7049718/hD9QaEy