### PR TITLE
Fix issue where customer orders and DLCs are incorrectly assigned to …

### DIFF
--- a/PRODUCTION-STORAGE-DEBUG-URGENT.md
+++ b/PRODUCTION-STORAGE-DEBUG-URGENT.md
@@ -1,0 +1,66 @@
+# Debug Production Storage - GroupId Mystery
+
+## Problème Production
+
+Utilisateur assigné magasin #2 crée DLC/commandes → apparaît magasin #1
+
+## Analyse Couche Storage
+
+Il y a 2 implémentations storage :
+
+### 1. MemStorage (Développement)
+```javascript
+async createDlcProduct(dlcProduct: any): Promise<any> { 
+    const newProduct = { id, ...dlcProduct, createdAt, updatedAt };
+    // Enregistre directement les données passées
+}
+```
+
+### 2. Drizzle ORM (Production)  
+```javascript
+async createDlcProduct(dlcProductData: InsertDlcProductFrontend): Promise<DlcProductFrontend> {
+    const { dlcDate, ...restData } = dlcProductData as any;
+    const [dlcProduct] = await db.insert(dlcProducts).values({
+        ...restData, // ⚠️ SI restData.groupId = 1, il sera enregistré tel quel
+        expiryDate: dlcDate,
+    });
+}
+```
+
+## Hypothèses du Problème
+
+1. **Frontend envoie groupId: 1** malgré les corrections
+2. **Backend force finalGroupId: 2** mais quelque chose le rechange
+3. **Storage reçoit groupId: 1** et l'enregistre tel quel
+4. **Base de données a une contrainte/trigger** qui force groupId: 1
+
+## Debug Ajouté
+
+### 1. Logs Storage Drizzle (Production)
+```javascript
+console.log("🔍 STORAGE DEBUG - DLC insertData:", insertData);
+console.log("🔍 STORAGE DEBUG - DLC insertData.groupId:", insertData.groupId, typeof insertData.groupId);
+console.log("🔍 STORAGE DEBUG - DLC returned from DB:", dlcProduct);
+console.log("🔍 STORAGE DEBUG - DLC returned groupId:", dlcProduct.groupId, typeof dlcProduct.groupId);
+```
+
+### 2. Même Logs pour Customer Orders
+
+## Plan de Debug Production
+
+1. ✅ **Logs routse backend** - Voir finalGroupId calculé
+2. ✅ **Logs storage layer** - Voir données envoyées à DB  
+3. ✅ **Logs retour DB** - Voir ce que la DB retourne
+4. 🔄 **Déployer en production**
+5. 🧪 **Tester création DLC/commande avec employé magasin #2**
+6. 📋 **Analyser logs complets pour identifier où groupId change**
+
+## Résultat Attendu
+
+Les logs révéleront :
+- Frontend calcule-t-il groupId: 2 ?
+- Backend force-t-il finalGroupId: 2 ?  
+- Storage reçoit-il groupId: 2 ?
+- DB retourne-t-elle groupId: 1 ou 2 ?
+
+**POINT DE RUPTURE IDENTIFIÉ = PROBLÈME RÉSOLU**

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2019,15 +2019,18 @@ RÉSUMÉ DU SCAN
       console.log("Backend data mapped:", backendData);
       
       // REMOVED: All role restrictions - tous les rôles peuvent créer des commandes client
-      console.log("Creating customer order - no role restrictions:", { 
+      console.log("🔍 PRODUCTION DEBUG - Creating customer order with data:", { 
         userId, 
         userRole: user.role, 
         userGroups: user.userGroups?.map(ug => ({groupId: ug.groupId, groupName: ug.group?.name})),
         originalGroupId: req.body.groupId,
-        finalGroupId: backendData.groupId 
+        finalGroupId: backendData.groupId,
+        backendDataGroupId: backendData.groupId
       });
 
+      console.log("🔍 PRODUCTION DEBUG - Calling storage.createCustomerOrder with groupId:", backendData.groupId);
       const customerOrder = await storage.createCustomerOrder(backendData);
+      console.log("🔍 PRODUCTION DEBUG - Customer order created with groupId:", customerOrder.groupId, "- Should be:", finalGroupId);
       res.status(201).json(customerOrder);
     } catch (error) {
       console.error("Error creating customer order:", error);
@@ -2406,15 +2409,22 @@ RÉSUMÉ DU SCAN
         combined: { ...req.body, createdBy: userId, groupId: finalGroupId }
       });
 
-      const validatedData = insertDlcProductFrontendSchema.parse({
+      const dataToValidate = {
         ...req.body,
         createdBy: userId,
         groupId: finalGroupId,
-      });
+      };
+      
+      console.log("🔍 PRODUCTION DEBUG - Data before validation:", dataToValidate);
+      
+      const validatedData = insertDlcProductFrontendSchema.parse(dataToValidate);
 
-      console.log("✅ Post-validation data:", validatedData);
+      console.log("✅ PRODUCTION DEBUG - Post-validation data:", validatedData);
+      console.log("🔍 PRODUCTION DEBUG - GroupId after validation:", validatedData.groupId, typeof validatedData.groupId);
 
+      console.log("🔍 PRODUCTION DEBUG - Calling storage.createDlcProduct with groupId:", validatedData.groupId);
       const dlcProduct = await storage.createDlcProduct(validatedData);
+      console.log("🔍 PRODUCTION DEBUG - DLC created with groupId:", dlcProduct.groupId, "- Should be:", finalGroupId);
       console.log("📦 Raw returned DLC product:", dlcProduct);
       console.log('✅ DLC Product created successfully:', {
         id: dlcProduct.id,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1252,14 +1252,23 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createCustomerOrder(customerOrderData: InsertCustomerOrder): Promise<CustomerOrder> {
+    const insertData = {
+      ...customerOrderData,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    
+    console.log("🔍 STORAGE DEBUG - Customer Order insertData:", insertData);
+    console.log("🔍 STORAGE DEBUG - Customer Order insertData.groupId:", insertData.groupId, typeof insertData.groupId);
+    
     const [customerOrder] = await db
       .insert(customerOrders)
-      .values({
-        ...customerOrderData,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      })
+      .values(insertData)
       .returning();
+    
+    console.log("🔍 STORAGE DEBUG - Customer Order returned from DB:", customerOrder);
+    console.log("🔍 STORAGE DEBUG - Customer Order returned groupId:", customerOrder.groupId, typeof customerOrder.groupId);
+    
     return customerOrder;
   }
 
@@ -1471,21 +1480,33 @@ export class DatabaseStorage implements IStorage {
   async createDlcProduct(dlcProductData: InsertDlcProductFrontend): Promise<DlcProductFrontend> {
     // Convert dlcDate to expiryDate for Drizzle schema compatibility
     const { dlcDate, ...restData } = dlcProductData as any;
+    
+    const insertData = {
+      ...restData,
+      expiryDate: dlcDate,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    
+    console.log("🔍 STORAGE DEBUG - DLC insertData:", insertData);
+    console.log("🔍 STORAGE DEBUG - DLC insertData.groupId:", insertData.groupId, typeof insertData.groupId);
+    
     const [dlcProduct] = await db
       .insert(dlcProducts)
-      .values({
-        ...restData,
-        expiryDate: dlcDate,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      })
+      .values(insertData)
       .returning();
     
+    console.log("🔍 STORAGE DEBUG - DLC returned from DB:", dlcProduct);
+    console.log("🔍 STORAGE DEBUG - DLC returned groupId:", dlcProduct.groupId, typeof dlcProduct.groupId);
+    
     // Return with dlcDate field for frontend compatibility
-    return {
+    const result = {
       ...dlcProduct,
       dlcDate: dlcProduct.expiryDate,
     } as any;
+    
+    console.log("🔍 STORAGE DEBUG - DLC final result:", result);
+    return result;
   }
 
   async updateDlcProduct(id: number, dlcProductData: Partial<InsertDlcProductFrontend>): Promise<DlcProductFrontend> {


### PR DESCRIPTION
…the wrong store

Add extensive logging to the storage layer and backend routes to diagnose and resolve an issue where customer orders and DLC products are being assigned to store #1 instead of the intended store #2, even when created by users associated with store #2. This includes detailed console logs within the `createCustomerOrder` and `createDlcProduct` functions in both the routes and storage layers, focusing on the `groupId` before and after database operations.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: b163d4c0-de5e-4f4e-a9c0-aed4c7049718
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/b163d4c0-de5e-4f4e-a9c0-aed4c7049718/32z3sin