### PR TITLE
Fix scrolling issue to display all lines on pages

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -90,7 +90,7 @@ export default function Layout({ children }: LayoutProps) {
         {/* Desktop Sidebar */}
         {!isMobile && <Sidebar />}
         
-        <main className={`flex-1 flex flex-col overflow-hidden ${
+        <main className={`flex-1 flex flex-col ${
           isMobile ? 'ml-0' : sidebarCollapsed ? 'ml-16' : 'ml-64'
         }`}>
           {/* Header with store selector for admin */}

--- a/client/src/pages/CustomerOrders.tsx
+++ b/client/src/pages/CustomerOrders.tsx
@@ -674,7 +674,7 @@ export default function CustomerOrders() {
   } = usePagination(sortedOrders, 10);
 
   return (
-    <div className="h-full overflow-y-auto">
+    <div className="flex-1 overflow-y-auto">
       <div className="p-6 space-y-6">
       {/* Header */}
       <div className="bg-white border-b border-gray-200 p-6 shadow-sm -m-6 mb-6">

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -218,7 +218,7 @@ export default function Dashboard() {
   };
 
   return (
-    <div className="h-full overflow-y-auto">
+    <div className="flex-1 overflow-y-auto">
       <div className="p-6 space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">

--- a/client/src/pages/Deliveries.tsx
+++ b/client/src/pages/Deliveries.tsx
@@ -255,7 +255,7 @@ export default function Deliveries() {
   const canValidate = permissions.canValidate('deliveries');
 
   return (
-    <div className="h-full overflow-y-auto">
+    <div className="flex-1 overflow-y-auto">
       <div className="p-6 space-y-6">
       {/* Header */}
       <div className="bg-white border-b border-gray-200 p-6 shadow-sm -m-6 mb-6">

--- a/client/src/pages/Orders.tsx
+++ b/client/src/pages/Orders.tsx
@@ -226,7 +226,7 @@ export default function Orders() {
   const canDelete = permissions.canDelete('orders');
 
   return (
-    <div className="h-full overflow-y-auto">
+    <div className="flex-1 overflow-y-auto">
       <div className="p-6 space-y-6">
       {/* Header */}
       <div className="bg-white border-b border-gray-200 p-6 shadow-sm -m-6 mb-6">


### PR DESCRIPTION
Adjust main content containers to use flex-1 for proper vertical scrolling across various pages, resolving an issue where some lines were not visible.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: cc8ba926-557c-4bf1-a2ea-ceabbcf38824
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/cc8ba926-557c-4bf1-a2ea-ceabbcf38824/ZtgwSaL