### PR TITLE
Add pagination to orders and center the difference column with right-…

### DIFF
--- a/client/src/pages/BLReconciliation.tsx
+++ b/client/src/pages/BLReconciliation.tsx
@@ -434,23 +434,25 @@ export default function BLReconciliation() {
                               </div>
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap text-center">
-                              {(() => {
-                                const blAmount = delivery.blAmount ? parseFloat(delivery.blAmount) : 0;
-                                const invoiceAmount = delivery.invoiceAmount ? parseFloat(delivery.invoiceAmount) : 0;
-                                if (blAmount && invoiceAmount) {
-                                  const diff = blAmount - invoiceAmount;
-                                  const diffAbs = Math.abs(diff);
-                                  return (
-                                    <div className={`font-medium ${
-                                      diff === 0 ? 'text-green-600' : 
-                                      diffAbs > 10 ? 'text-red-600' : 'text-orange-600'
-                                    }`}>
-                                      {diff > 0 ? '+' : ''}{diff.toFixed(2)}€
-                                    </div>
-                                  );
-                                }
-                                return <span className="text-gray-400 italic text-xs">-</span>;
-                              })()}
+                              <div className="flex justify-center">
+                                {(() => {
+                                  const blAmount = delivery.blAmount ? parseFloat(delivery.blAmount) : 0;
+                                  const invoiceAmount = delivery.invoiceAmount ? parseFloat(delivery.invoiceAmount) : 0;
+                                  if (blAmount && invoiceAmount) {
+                                    const diff = blAmount - invoiceAmount;
+                                    const diffAbs = Math.abs(diff);
+                                    return (
+                                      <div className={`font-medium text-right ${
+                                        diff === 0 ? 'text-green-600' : 
+                                        diffAbs > 10 ? 'text-red-600' : 'text-orange-600'
+                                      }`}>
+                                        {diff > 0 ? '+' : ''}{diff.toFixed(2)}€
+                                      </div>
+                                    );
+                                  }
+                                  return <span className="text-gray-400 italic text-xs">-</span>;
+                                })()}
+                              </div>
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap">
                               <div className="text-sm text-gray-900">

--- a/client/src/pages/Orders.tsx
+++ b/client/src/pages/Orders.tsx
@@ -411,15 +411,16 @@ export default function Orders() {
               </div>
               
               {/* Pagination */}
-              <Pagination
-                currentPage={currentPage}
-                totalPages={totalPages}
-                totalItems={totalItems}
-                itemsPerPage={itemsPerPage}
-                onPageChange={setCurrentPage}
-                onItemsPerPageChange={setItemsPerPage}
-                className="mt-4 p-4 border-t border-gray-200"
-              />
+              <div className="p-4 border-t border-gray-200">
+                <Pagination
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  totalItems={totalItems}
+                  itemsPerPage={itemsPerPage}
+                  onPageChange={setCurrentPage}
+                  onItemsPerPageChange={setItemsPerPage}
+                />
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
…aligned data

Implement pagination for the orders page and adjust the reconciliation screen to center the difference column with right-aligned numerical data.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 76582ba3-44cb-4730-92fa-66f28725967b
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/76582ba3-44cb-4730-92fa-66f28725967b/wLa3UqB