### PR TITLE
Center the difference column in the reconciliation module

### DIFF
--- a/client/src/pages/BLReconciliation.tsx
+++ b/client/src/pages/BLReconciliation.tsx
@@ -434,25 +434,23 @@ export default function BLReconciliation() {
                               </div>
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap text-center">
-                              <div className="flex justify-center">
-                                {(() => {
-                                  const blAmount = delivery.blAmount ? parseFloat(delivery.blAmount) : 0;
-                                  const invoiceAmount = delivery.invoiceAmount ? parseFloat(delivery.invoiceAmount) : 0;
-                                  if (blAmount && invoiceAmount) {
-                                    const diff = blAmount - invoiceAmount;
-                                    const diffAbs = Math.abs(diff);
-                                    return (
-                                      <div className={`font-medium text-right ${
-                                        diff === 0 ? 'text-green-600' : 
-                                        diffAbs > 10 ? 'text-red-600' : 'text-orange-600'
-                                      }`}>
-                                        {diff > 0 ? '+' : ''}{diff.toFixed(2)}€
-                                      </div>
-                                    );
-                                  }
-                                  return <span className="text-gray-400 italic text-xs">-</span>;
-                                })()}
-                              </div>
+                              {(() => {
+                                const blAmount = delivery.blAmount ? parseFloat(delivery.blAmount) : 0;
+                                const invoiceAmount = delivery.invoiceAmount ? parseFloat(delivery.invoiceAmount) : 0;
+                                if (blAmount && invoiceAmount) {
+                                  const diff = blAmount - invoiceAmount;
+                                  const diffAbs = Math.abs(diff);
+                                  return (
+                                    <div className={`font-medium text-center ${
+                                      diff === 0 ? 'text-green-600' : 
+                                      diffAbs > 10 ? 'text-red-600' : 'text-orange-600'
+                                    }`}>
+                                      {diff > 0 ? '+' : ''}{diff.toFixed(2)}€
+                                    </div>
+                                  );
+                                }
+                                return <span className="text-gray-400 italic text-xs">-</span>;
+                              })()}
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap">
                               <div className="text-sm text-gray-900">


### PR DESCRIPTION
Updates the `BLReconciliation.tsx` file to center-align the displayed difference amount in the reconciliation table by changing the `justify-center` class to `text-center` within the relevant table cell.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 76582ba3-44cb-4730-92fa-66f28725967b
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/76582ba3-44cb-4730-92fa-66f28725967b/wLa3UqB