### PR TITLE
Adjust invoice reference display to move it to the left side

### DIFF
--- a/client/src/pages/BLReconciliation.tsx
+++ b/client/src/pages/BLReconciliation.tsx
@@ -656,12 +656,6 @@ export default function BLReconciliation() {
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap">
                               <div className="flex items-center space-x-2">
-                                <div className={`text-sm ${delivery.reconciled !== true ? 'font-medium text-gray-900' : 'text-gray-600'}`}>
-                                  {delivery.invoiceReference || (
-                                    <span className="text-gray-400 italic">Non renseigné</span>
-                                  )}
-                                </div>
-                                
                                 {/* Icône de vérification de facture */}
                                 {(delivery.group?.nocodbTableName || delivery.group?.nocodbConfigId || delivery.group?.webhookUrl) && (
                                   <div className="flex items-center">
@@ -690,6 +684,12 @@ export default function BLReconciliation() {
                                     )}
                                   </div>
                                 )}
+                                
+                                <div className={`text-sm ${delivery.reconciled !== true ? 'font-medium text-gray-900' : 'text-gray-600'}`}>
+                                  {delivery.invoiceReference || (
+                                    <span className="text-gray-400 italic">Non renseigné</span>
+                                  )}
+                                </div>
                               </div>
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap">


### PR DESCRIPTION
Adjusted the layout in the BLReconciliation page to move the invoice reference display to the left column.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 7c468936-2a88-4686-ac0a-84921a45222d
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/7c468936-2a88-4686-ac0a-84921a45222d/0V9QMsa