### PR TITLE
Restore visibility of linked order and delivery information in calend…

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -564,13 +564,14 @@ export type OrderWithRelations = Order & {
   supplier: Supplier;
   group: Group;
   creator: User;
+  deliveries?: DeliveryWithRelations[];
 };
 
 export type DeliveryWithRelations = Delivery & {
   supplier: Supplier;
   group: Group;
   creator: User;
-  order?: Order;
+  order?: OrderWithRelations;
 };
 
 export type PublicityWithRelations = Publicity & {


### PR DESCRIPTION
…ar views

Update storage logic to include associated deliveries within order details and link orders to delivery details.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 7c468936-2a88-4686-ac0a-84921a45222d
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/7c468936-2a88-4686-ac0a-84921a45222d/tzcQQt9