### PR TITLE
Correctly plan orders when creating deliveries and linking them

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1677,11 +1677,25 @@ export class MemStorage implements IStorage {
     const delivery: Delivery = {
       id,
       ...deliveryData,
-      status: 'pending',
+      status: 'planned', // Livraisons créées sont automatiquement planifiées
       createdAt: new Date(),
       updatedAt: new Date(),
     };
     this.deliveries.set(id, delivery);
+    
+    // Si une commande est liée, la marquer comme "planned" (pas delivered!)
+    if (deliveryData.orderId) {
+      try {
+        const order = this.orders.get(deliveryData.orderId);
+        if (order && order.status === 'pending') {
+          console.log(`🔗 Delivery #${id} linked to order #${deliveryData.orderId}, updating order status to 'planned'`);
+          await this.updateOrder(deliveryData.orderId, { status: 'planned' });
+        }
+      } catch (error) {
+        console.error(`❌ Failed to update order #${deliveryData.orderId} status to planned:`, error);
+      }
+    }
+    
     return delivery;
   }
 


### PR DESCRIPTION
Adjust delivery creation logic in server/routes.ts and server/storage.ts to set the initial delivery status to 'planned' instead of 'delivered'. This change also ensures that linked orders are updated to a 'planned' status, preventing incorrect 'delivered' status assignments and resolving the issue where orders were being marked as delivered prematurely.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 7c468936-2a88-4686-ac0a-84921a45222d
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/7c468936-2a88-4686-ac0a-84921a45222d/I42UgiS