### PR TITLE
Allow directors to validate DLCs and fix validation button visibility

### DIFF
--- a/attached_assets/Pasted--hasFormat-true-Password-comparison-result-true-POST-api-login-200-in-86ms-GE-1755291651004_1755291651005.txt
+++ b/attached_assets/Pasted--hasFormat-true-Password-comparison-result-true-POST-api-login-200-in-86ms-GE-1755291651004_1755291651005.txt
@@ -1,0 +1,200 @@
+
+  hasFormat: true
+
+}
+
+🔐 Password comparison result: true
+
+POST /api/login 200 in 86ms
+
+GET /api/user 200 in 12ms
+
+GET /api/user 304 in 20ms
+
+Customer Orders API called with: { groupIds: undefined, userRole: 'admin' }
+
+Customer Orders returned: 37 items
+
+GET /api/customer-orders 200 in 89ms
+
+🗓️ [DATE-CALC] Aujourd'hui: 2025-08-15 (Vendredi)
+
+🗓️ [DATE-CALC] Année précédente: 2024-08-16 (Vendredi)
+
+📊 Calcul statistiques mensuelles: {
+
+  year: 2025,
+
+  month: 8,
+
+  startDate: '2025-08-01',
+
+  endDate: '2025-09-01',
+
+  groupIds: undefined
+
+}
+
+Orders API called with: {
+
+  startDate: undefined,
+
+  endDate: undefined,
+
+  storeId: undefined,
+
+  userRole: 'admin'
+
+}
+
+Admin filtering with groupIds: undefined
+
+Fetching all orders
+
+🌤️ [RESPONSE] Weather data prepared: {
+
+  hasCurrentYear: true,
+
+  hasPreviousYear: true,
+
+  location: 'Frouard, France'
+
+}
+
+GET /api/publicities 304 in 152ms
+
+GET /api/user 304 in 129ms
+
+GET /api/weather/current 304 in 177ms
+
+🔍 Tasks API called with: {
+
+  groupIds: undefined,
+
+  userRole: 'admin',
+
+  userId: 'admin_local',
+
+  requestedStoreId: undefined,
+
+  userGroups: 'all'
+
+}
+
+Deliveries API called with: {
+
+  startDate: undefined,
+
+  endDate: undefined,
+
+  storeId: undefined,
+
+  withBL: undefined,
+
+  userRole: 'admin'
+
+}
+
+Admin filtering deliveries with groupIds: undefined
+
+Fetching all deliveries
+
+📋 Tasks returned: 55 items for user: admin_local
+
+GET /api/tasks 200 in 324ms
+
+GET /api/dlc-products/stats 200 in 332ms
+
+🔗 PRODUCTION: getDeliveries() récupéré 86 livraisons avec relations
+
+Deliveries returned: 86 items
+
+GET /api/deliveries 200 in 511ms
+
+🔗 PRODUCTION: getOrders() récupéré 51 commandes avec relations
+
+Orders returned: 51 items
+
+GET /api/orders 200 in 523ms
+
+Customer Orders API called with: { groupIds: [ 1 ], userRole: 'admin' }
+
+GET /api/user 304 in 156ms
+
+Deliveries API called with: {
+
+  startDate: undefined,
+
+  endDate: undefined,
+
+  storeId: '1',
+
+  withBL: undefined,
+
+  userRole: 'admin'
+
+}
+
+Admin filtering deliveries with groupIds: [ 1 ]
+
+Fetching all deliveries
+
+Orders API called with: {
+
+  startDate: undefined,
+
+  endDate: undefined,
+
+  storeId: '1',
+
+  userRole: 'admin'
+
+}
+
+Admin filtering with groupIds: [ 1 ]
+
+Fetching all orders
+
+📊 Statistiques calculées: {
+
+  ordersCount: 20,
+
+  deliveriesCount: 42,
+
+  pendingOrdersCount: 8,
+
+  averageDeliveryTime: 0.3611111111111111,
+
+  totalPalettes: 120,
+
+  totalPackages: 36
+
+}
+
+GET /api/stats/monthly 200 in 542ms
+
+GET /api/publicities 304 in 153ms
+
+Customer Orders returned: 9 items
+
+GET /api/customer-orders 304 in 136ms
+
+🔗 PRODUCTION: getDeliveries() récupéré 48 livraisons avec relations
+
+Deliveries returned: 48 items
+
+GET /api/deliveries 304 in 202ms
+
+🔗 PRODUCTION: getOrders() récupéré 33 commandes avec relations
+
+Orders returned: 33 items
+
+GET /api/orders 304 in 275ms
+
+GET /api/groups 200 in 74ms
+
+GET /api/user 304 in 10ms
+
+GET /api/suppliers 304 in 7ms
+
+GET /api/dlc-products 304 in 37ms

--- a/client/src/pages/DlcPage.tsx
+++ b/client/src/pages/DlcPage.tsx
@@ -282,7 +282,8 @@ export default function DlcPage() {
     const daysUntilExpiry = Math.ceil((expiry.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
     
     // Afficher le bouton si le produit expire dans 15 jours ou moins, ou est déjà expiré
-    return (daysUntilExpiry <= 15 && product.status !== "valide");
+    // ET si le produit n'est pas déjà validé
+    return (daysUntilExpiry <= 15 && product.status !== "valides");
   };
 
   const getStatusBadge = (status: string, dlcDate: string | null) => {
@@ -791,7 +792,7 @@ export default function DlcPage() {
                             >
                               <Edit className="w-4 h-4" />
                             </Button>
-                            {shouldShowValidateButton(product) && (user?.role === 'admin' || user?.role === 'manager') && (
+                            {shouldShowValidateButton(product) && (user?.role === 'admin' || user?.role === 'manager' || user?.role === 'directeur') && (
                               <Button
                                 variant="default"
                                 size="sm"


### PR DESCRIPTION
Correct the product status check for validation and grant 'directeur' role the ability to see the validate button in DlcPage.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: a3de0820-9397-41b2-b000-7931ee9c29de
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/a3de0820-9397-41b2-b000-7931ee9c29de/emyZ6I3