### PR TITLE
Provide instructions to fix missing announcement table in production

### DIFF
--- a/INSTRUCTIONS_PRODUCTION.md
+++ b/INSTRUCTIONS_PRODUCTION.md
@@ -1,0 +1,38 @@
+# Instructions pour corriger la production
+
+## Problème identifié
+La table `announcements` n'existe pas dans votre base de données de production.
+
+## Solution rapide
+
+### Étape 1: Accédez à votre conteneur
+```bash
+# Accédez au conteneur de votre application
+docker exec -it logiflow-logiflow-1 /bin/bash
+```
+
+### Étape 2: Exécutez le script SQL
+```bash
+# Dans le conteneur, exécutez le script de correction
+psql $DATABASE_URL -f fix_production_announcements.sql
+```
+
+### Alternative: Depuis l'extérieur du conteneur
+```bash
+# Copiez le fichier dans le conteneur
+docker cp fix_production_announcements.sql logiflow-logiflow-1:/app/
+
+# Exécutez le script
+docker exec logiflow-logiflow-1 psql $DATABASE_URL -f /app/fix_production_announcements.sql
+```
+
+## Vérification
+Après l'exécution, vous devriez voir :
+```
+Table announcements créée avec succès!
+```
+
+Le système d'annonces fonctionnera immédiatement après cette correction.
+
+## Prévention future
+Pour éviter ce problème lors des futures mises à jour, utilisez le fichier `init.sql` pour les nouvelles installations.

--- a/attached_assets/Pasted--Events-Host-Administration-User-related-Environment-related-Registries-Logs--1755341367149_1755341367149.txt
+++ b/attached_assets/Pasted--Events-Host-Administration-User-related-Environment-related-Registries-Logs--1755341367149_1755341367149.txt
@@ -1,0 +1,243 @@
+
+Events
+
+Host
+
+Administration
+
+User-related
+
+
+Environment-related
+
+Registries
+
+Logs
+
+Notifications
+
+Settings
+
+New version available 2.27.9
+DismissSee what's new
+Community Edition
+2.27.6 LTS
+Containers>logiflow-logiflow-1>Logs
+Container logs
+
+
+admin
+Log viewer settings
+Auto-refresh logs
+Wrap lines
+Display timestamps
+Fetch
+All logs
+Search
+Filter...
+Lines
+100
+Actions
+ 
+ 
+ 
+      
+  where: undefined,
+
+  schema: undefined,
+
+  table: undefined,
+
+  column: undefined,
+
+  dataType: undefined,
+
+  constraint: undefined,
+
+  file: 'parse_relation.c',
+
+  line: '1392',
+
+  routine: 'parserOpenTable'
+
+}
+
+GET /api/announcements 500 in 294ms
+
+🔗 PRODUCTION: getOrders() récupéré 51 commandes avec relations
+
+Orders returned: 51 items
+
+GET /api/orders 200 in 358ms
+
+GET /api/dlc-products/stats 200 in 360ms
+
+🔗 PRODUCTION: getDeliveries() récupéré 86 livraisons avec relations
+
+Deliveries returned: 86 items
+
+GET /api/deliveries 200 in 388ms
+
+Orders API called with: {
+
+  startDate: undefined,
+
+  endDate: undefined,
+
+  storeId: '1',
+
+  userRole: 'admin'
+
+}
+
+Admin filtering with groupIds: [ 1 ]
+
+Fetching all orders
+
+Customer Orders API called with: { groupIds: undefined, userRole: 'admin' }
+
+Deliveries API called with: {
+
+  startDate: undefined,
+
+  endDate: undefined,
+
+  storeId: '1',
+
+  withBL: undefined,
+
+  userRole: 'admin'
+
+}
+
+Admin filtering deliveries with groupIds: [ 1 ]
+
+Fetching all deliveries
+
+GET /api/publicities 200 in 431ms
+
+Customer Orders API called with: { groupIds: [ 1 ], userRole: 'admin' }
+
+Customer Orders returned: 38 items
+
+GET /api/customer-orders 200 in 472ms
+
+🔗 PRODUCTION: getOrders() récupéré 33 commandes avec relations
+
+Orders returned: 33 items
+
+GET /api/orders 200 in 199ms
+
+🔗 PRODUCTION: getDeliveries() récupéré 48 livraisons avec relations
+
+Deliveries returned: 48 items
+
+Customer Orders returned: 10 items
+
+GET /api/deliveries 200 in 217ms
+
+GET /api/customer-orders 200 in 203ms
+
+GET /api/publicities 200 in 58ms
+
+Error fetching announcements: error: relation "announcements" does not exist
+
+    at /app/node_modules/pg-pool/index.js:45:11
+
+    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+
+    at async file:///app/node_modules/drizzle-orm/node-postgres/session.js:83:22
+
+    at async DatabaseStorage.getAnnouncements (file:///app/dist/index.js:2074:25)
+
+    at async file:///app/dist/index.js:7420:30 {
+
+  length: 113,
+
+  severity: 'ERROR',
+
+  code: '42P01',
+
+  detail: undefined,
+
+  hint: undefined,
+
+  position: '829',
+
+  internalPosition: undefined,
+
+  internalQuery: undefined,
+
+  where: undefined,
+
+  schema: undefined,
+
+  table: undefined,
+
+  column: undefined,
+
+  dataType: undefined,
+
+  constraint: undefined,
+
+  file: 'parse_relation.c',
+
+  line: '1392',
+
+  routine: 'parserOpenTable'
+
+}
+
+GET /api/announcements 500 in 10ms
+
+Error fetching announcements: error: relation "announcements" does not exist
+
+    at /app/node_modules/pg-pool/index.js:45:11
+
+    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+
+    at async file:///app/node_modules/drizzle-orm/node-postgres/session.js:83:22
+
+    at async DatabaseStorage.getAnnouncements (file:///app/dist/index.js:2074:25)
+
+    at async file:///app/dist/index.js:7420:30 {
+
+  length: 113,
+
+  severity: 'ERROR',
+
+  code: '42P01',
+
+  detail: undefined,
+
+  hint: undefined,
+
+  position: '829',
+
+  internalPosition: undefined,
+
+  internalQuery: undefined,
+
+  where: undefined,
+
+  schema: undefined,
+
+  table: undefined,
+
+  column: undefined,
+
+  dataType: undefined,
+
+  constraint: undefined,
+
+  file: 'parse_relation.c',
+
+  line: '1392',
+
+  routine: 'parserOpenTable'
+
+}
+
+GET /api/announcements 500 in 14ms
+
+HEAD /api/health 200 in 0ms

--- a/fix_production_announcements.sql
+++ b/fix_production_announcements.sql
@@ -1,0 +1,38 @@
+-- Script de correction production pour créer la table announcements
+-- À exécuter dans votre conteneur Docker
+
+BEGIN;
+
+-- Création de la table announcements
+CREATE TABLE IF NOT EXISTS announcements (
+  id SERIAL PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  content TEXT NOT NULL,
+  priority VARCHAR(20) NOT NULL DEFAULT 'normal' CHECK (priority IN ('normal', 'important', 'urgent')),
+  author_id VARCHAR(255) NOT NULL,
+  group_id INTEGER,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  CONSTRAINT announcements_author_id_fkey FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE,
+  CONSTRAINT announcements_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE
+);
+
+-- Création des index
+CREATE INDEX IF NOT EXISTS idx_announcements_priority ON announcements(priority);
+CREATE INDEX IF NOT EXISTS idx_announcements_created_at ON announcements(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_announcements_author_id ON announcements(author_id);
+CREATE INDEX IF NOT EXISTS idx_announcements_group_id ON announcements(group_id);
+
+-- Commentaires
+COMMENT ON TABLE announcements IS 'Admin-managed announcements/information system';
+COMMENT ON COLUMN announcements.priority IS 'Priority level: normal, important, urgent';
+COMMENT ON COLUMN announcements.group_id IS 'NULL for global announcements, specific group_id for store-specific announcements';
+
+-- Vérification
+SELECT 
+  'Table announcements créée avec succès!' as message,
+  COUNT(*) as nb_colonnes
+FROM information_schema.columns 
+WHERE table_name = 'announcements';
+
+COMMIT;


### PR DESCRIPTION
Add a new file `INSTRUCTIONS_PRODUCTION.md` detailing steps to resolve the "relation "announcements" does not exist" error in the production environment, along with a SQL script `fix_production_announcements.sql` to create the missing table.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: e437ffed-c31b-44eb-9fd5-b6f9faa8e7ce
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/e437ffed-c31b-44eb-9fd5-b6f9faa8e7ce/biGr9ER