### PR TITLE
Create announcement table to fix production database errors

### DIFF
--- a/attached_assets/Pasted--Host-Administration-User-related-Environment-related-Registries-Logs-Notific-1755342677754_1755342677754.txt
+++ b/attached_assets/Pasted--Host-Administration-User-related-Environment-related-Registries-Logs-Notific-1755342677754_1755342677754.txt
@@ -1,0 +1,242 @@
+
+
+Host
+
+Administration
+
+User-related
+
+
+Environment-related
+
+Registries
+
+Logs
+
+Notifications
+
+Settings
+
+New version available 2.27.9
+DismissSee what's new
+Community Edition
+2.27.6 LTS
+Containers>logiflow-logiflow-1>Logs
+Container logs
+
+
+admin
+Log viewer settings
+Auto-refresh logs
+Wrap lines
+Display timestamps
+Fetch
+All logs
+Search
+Filter...
+Lines
+100
+Actions
+ 
+ 
+ 
+      
+}
+
+GET /api/user 200 in 213ms
+
+GET /api/deliveries 200 in 285ms
+
+Customer Orders returned: 38 items
+
+🔗 PRODUCTION: getOrders() récupéré 51 commandes avec relations
+
+Orders returned: 51 items
+
+GET /api/customer-orders 200 in 287ms
+
+GET /api/orders 200 in 302ms
+
+Orders API called with: {
+
+  startDate: undefined,
+
+  endDate: undefined,
+
+  storeId: '1',
+
+  userRole: 'admin'
+
+}
+
+Admin filtering with groupIds: [ 1 ]
+
+Fetching all orders
+
+Deliveries API called with: {
+
+  startDate: undefined,
+
+  endDate: undefined,
+
+  storeId: '1',
+
+  withBL: undefined,
+
+  userRole: 'admin'
+
+}
+
+Admin filtering deliveries with groupIds: [ 1 ]
+
+Fetching all deliveries
+
+Customer Orders API called with: { groupIds: [ 1 ], userRole: 'admin' }
+
+📋 Tasks returned: {
+
+  count: 55,
+
+  userId: 'admin_local',
+
+  userRole: 'admin',
+
+  requestedStoreId: undefined,
+
+  groupIds: undefined,
+
+  taskGroups: [
+
+    { id: 91, title: 'refaire podium lot assiettes', groupId: 2 },
+
+    { id: 90, title: 'caisse 1', groupId: 1 },
+
+    { id: 89, title: 'caisse 3', groupId: 1 }
+
+  ]
+
+}
+
+GET /api/groups 200 in 169ms
+
+GET /api/tasks 200 in 277ms
+
+🔗 PRODUCTION: getDeliveries() récupéré 48 livraisons avec relations
+
+Deliveries returned: 48 items
+
+GET /api/deliveries 200 in 215ms
+
+Customer Orders returned: 10 items
+
+GET /api/customer-orders 200 in 214ms
+
+🔗 PRODUCTION: getOrders() récupéré 33 commandes avec relations
+
+Orders returned: 33 items
+
+GET /api/orders 200 in 243ms
+
+GET /api/publicities 200 in 121ms
+
+Error fetching announcements: error: relation "announcements" does not exist
+
+    at /app/node_modules/pg-pool/index.js:45:11
+
+    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+
+    at async file:///app/node_modules/drizzle-orm/node-postgres/session.js:83:22
+
+    at async DatabaseStorage.getAnnouncements (file:///app/dist/index.js:2074:25)
+
+    at async file:///app/dist/index.js:7420:30 {
+
+  length: 113,
+
+  severity: 'ERROR',
+
+  code: '42P01',
+
+  detail: undefined,
+
+  hint: undefined,
+
+  position: '829',
+
+  internalPosition: undefined,
+
+  internalQuery: undefined,
+
+  where: undefined,
+
+  schema: undefined,
+
+  table: undefined,
+
+  column: undefined,
+
+  dataType: undefined,
+
+  constraint: undefined,
+
+  file: 'parse_relation.c',
+
+  line: '1392',
+
+  routine: 'parserOpenTable'
+
+}
+
+GET /api/announcements 500 in 13ms
+
+HEAD /api/health 200 in 2ms
+
+Error fetching announcements: error: relation "announcements" does not exist
+
+    at /app/node_modules/pg-pool/index.js:45:11
+
+    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+
+    at async file:///app/node_modules/drizzle-orm/node-postgres/session.js:83:22
+
+    at async DatabaseStorage.getAnnouncements (file:///app/dist/index.js:2074:25)
+
+    at async file:///app/dist/index.js:7420:30 {
+
+  length: 113,
+
+  severity: 'ERROR',
+
+  code: '42P01',
+
+  detail: undefined,
+
+  hint: undefined,
+
+  position: '829',
+
+  internalPosition: undefined,
+
+  internalQuery: undefined,
+
+  where: undefined,
+
+  schema: undefined,
+
+  table: undefined,
+
+  column: undefined,
+
+  dataType: undefined,
+
+  constraint: undefined,
+
+  file: 'parse_relation.c',
+
+  line: '1392',
+
+  routine: 'parserOpenTable'
+
+}
+
+GET /api/announcements 500 in 11ms

--- a/test_db_access.sh
+++ b/test_db_access.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Script de test d'accès à la base de données
+
+echo "🔍 Test d'accès à la base de données..."
+
+# Test de connexion
+echo "1. Test de connexion à la base..."
+docker exec logiflow-logiflow-1 psql "$DATABASE_URL" -c "SELECT version();" > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    echo "✅ Connexion à la base réussie"
+else
+    echo "❌ Erreur de connexion à la base"
+    exit 1
+fi
+
+# Liste des tables existantes
+echo "2. Tables existantes dans la base:"
+docker exec logiflow-logiflow-1 psql "$DATABASE_URL" -c "
+SELECT tablename 
+FROM pg_tables 
+WHERE schemaname = 'public' 
+ORDER BY tablename;
+"
+
+# Vérification spécifique de la table announcements
+echo "3. Vérification de la table announcements:"
+docker exec logiflow-logiflow-1 psql "$DATABASE_URL" -c "
+SELECT EXISTS (
+  SELECT FROM information_schema.tables 
+  WHERE table_schema = 'public' 
+  AND table_name = 'announcements'
+) as announcements_exists;
+"
+
+echo "✅ Test terminé!"

--- a/urgent_production_fix.sh
+++ b/urgent_production_fix.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Script de correction urgente pour la production
+# Exécuter depuis votre serveur de production
+
+echo "🔧 Correction urgente pour la table announcements..."
+
+# Création de la table via commande SQL directe
+docker exec logiflow-logiflow-1 psql "$DATABASE_URL" -c "
+CREATE TABLE IF NOT EXISTS announcements (
+  id SERIAL PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  content TEXT NOT NULL,
+  priority VARCHAR(20) NOT NULL DEFAULT 'normal' CHECK (priority IN ('normal', 'important', 'urgent')),
+  author_id VARCHAR(255) NOT NULL,
+  group_id INTEGER,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  CONSTRAINT announcements_author_id_fkey FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE,
+  CONSTRAINT announcements_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_announcements_priority ON announcements(priority);
+CREATE INDEX IF NOT EXISTS idx_announcements_created_at ON announcements(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_announcements_author_id ON announcements(author_id);
+CREATE INDEX IF NOT EXISTS idx_announcements_group_id ON announcements(group_id);
+
+COMMENT ON TABLE announcements IS 'Admin-managed announcements/information system';
+"
+
+# Vérification de la création
+echo "🔍 Vérification de la table..."
+docker exec logiflow-logiflow-1 psql "$DATABASE_URL" -c "
+SELECT 'SUCCESS: Table announcements créée!' as status 
+FROM information_schema.tables 
+WHERE table_name = 'announcements';
+"
+
+echo "✅ Script terminé!"


### PR DESCRIPTION
Create the 'announcements' table in the production PostgreSQL database using a SQL script to resolve "relation 'announcements' does not exist" errors.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: e437ffed-c31b-44eb-9fd5-b6f9faa8e7ce
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/e437ffed-c31b-44eb-9fd5-b6f9faa8e7ce/biGr9ER