### PR TITLE
Fix error when accessing announcements and update production scripts

### DIFF
--- a/attached_assets/Pasted-Actions-GET-api-dlc-products-stats-200-in-302ms-PRODUCTION-getOrders-r-c-1755345846330_1755345846331.txt
+++ b/attached_assets/Pasted-Actions-GET-api-dlc-products-stats-200-in-302ms-PRODUCTION-getOrders-r-c-1755345846330_1755345846331.txt
@@ -1,0 +1,205 @@
+Actions
+ 
+ 
+ 
+      
+GET /api/dlc-products/stats 200 in 302ms
+
+🔗 PRODUCTION: getOrders() récupéré 51 commandes avec relations
+
+Orders returned: 51 items
+
+GET /api/orders 200 in 434ms
+
+GET /api/groups 200 in 346ms
+
+🌤️ [RESPONSE] Weather data prepared: {
+
+  hasCurrentYear: true,
+
+  hasPreviousYear: true,
+
+  location: 'Frouard, France'
+
+}
+
+GET /api/weather/current 200 in 446ms
+
+📊 Statistiques calculées: {
+
+  ordersCount: 20,
+
+  deliveriesCount: 42,
+
+  pendingOrdersCount: 8,
+
+  averageDeliveryTime: 0.3611111111111111,
+
+  totalPalettes: 120,
+
+  totalPackages: 36
+
+}
+
+GET /api/stats/monthly 200 in 444ms
+
+Orders API called with: {
+
+  startDate: undefined,
+
+  endDate: undefined,
+
+  storeId: '1',
+
+  userRole: 'admin'
+
+}
+
+Admin filtering with groupIds: [ 1 ]
+
+Fetching all orders
+
+Customer Orders API called with: { groupIds: [ 1 ], userRole: 'admin' }
+
+Deliveries API called with: {
+
+  startDate: undefined,
+
+  endDate: undefined,
+
+  storeId: '1',
+
+  withBL: undefined,
+
+  userRole: 'admin'
+
+}
+
+Admin filtering deliveries with groupIds: [ 1 ]
+
+Fetching all deliveries
+
+🔗 PRODUCTION: getDeliveries() récupéré 86 livraisons avec relations
+
+Deliveries returned: 86 items
+
+GET /api/deliveries 200 in 455ms
+
+Customer Orders returned: 10 items
+
+GET /api/customer-orders 200 in 132ms
+
+🔗 PRODUCTION: getOrders() récupéré 33 commandes avec relations
+
+Orders returned: 33 items
+
+GET /api/orders 200 in 295ms
+
+🔗 PRODUCTION: getDeliveries() récupéré 48 livraisons avec relations
+
+Deliveries returned: 48 items
+
+GET /api/deliveries 200 in 248ms
+
+Error fetching announcements: error: relation "announcements" does not exist
+
+    at /app/node_modules/pg-pool/index.js:45:11
+
+    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+
+    at async file:///app/node_modules/drizzle-orm/node-postgres/session.js:83:22
+
+    at async DatabaseStorage.getAnnouncements (file:///app/dist/index.js:2074:25)
+
+    at async file:///app/dist/index.js:7420:30 {
+
+  length: 113,
+
+  severity: 'ERROR',
+
+  code: '42P01',
+
+  detail: undefined,
+
+  hint: undefined,
+
+  position: '829',
+
+  internalPosition: undefined,
+
+  internalQuery: undefined,
+
+  where: undefined,
+
+  schema: undefined,
+
+  table: undefined,
+
+  column: undefined,
+
+  dataType: undefined,
+
+  constraint: undefined,
+
+  file: 'parse_relation.c',
+
+  line: '1392',
+
+  routine: 'parserOpenTable'
+
+}
+
+GET /api/announcements 500 in 7ms
+
+Error fetching announcements: error: relation "announcements" does not exist
+
+    at /app/node_modules/pg-pool/index.js:45:11
+
+    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+
+    at async file:///app/node_modules/drizzle-orm/node-postgres/session.js:83:22
+
+    at async DatabaseStorage.getAnnouncements (file:///app/dist/index.js:2074:25)
+
+    at async file:///app/dist/index.js:7420:30 {
+
+  length: 113,
+
+  severity: 'ERROR',
+
+  code: '42P01',
+
+  detail: undefined,
+
+  hint: undefined,
+
+  position: '829',
+
+  internalPosition: undefined,
+
+  internalQuery: undefined,
+
+  where: undefined,
+
+  schema: undefined,
+
+  table: undefined,
+
+  column: undefined,
+
+  dataType: undefined,
+
+  constraint: undefined,
+
+  file: 'parse_relation.c',
+
+  line: '1392',
+
+  routine: 'parserOpenTable'
+
+}
+
+GET /api/announcements 500 in 11ms
+
+HEAD /api/health 200 in 1ms
+

--- a/create_announcements_production.sql
+++ b/create_announcements_production.sql
@@ -1,30 +1,26 @@
--- Script pour créer la table announcements en production
--- Exécuter avec : psql -d votre_base -f create_announcements_production.sql
+-- Script SQL simple pour créer UNIQUEMENT la table announcements en production
+-- À exécuter directement dans le conteneur Docker
 
--- Création de la table announcements
 CREATE TABLE IF NOT EXISTS announcements (
   id SERIAL PRIMARY KEY,
   title VARCHAR(255) NOT NULL,
   content TEXT NOT NULL,
-  priority VARCHAR(20) NOT NULL DEFAULT 'normal' CHECK (priority IN ('normal', 'important', 'urgent')),
+  priority VARCHAR(20) NOT NULL DEFAULT 'normal',
   author_id VARCHAR(255) NOT NULL,
   group_id INTEGER,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  CONSTRAINT announcements_priority_check CHECK (priority IN ('normal', 'important', 'urgent')),
   CONSTRAINT announcements_author_id_fkey FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE,
   CONSTRAINT announcements_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE
 );
 
--- Création des index
+-- Créer les index pour les performances
 CREATE INDEX IF NOT EXISTS idx_announcements_priority ON announcements(priority);
 CREATE INDEX IF NOT EXISTS idx_announcements_created_at ON announcements(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_announcements_author_id ON announcements(author_id);
 CREATE INDEX IF NOT EXISTS idx_announcements_group_id ON announcements(group_id);
 
--- Commentaires
-COMMENT ON TABLE announcements IS 'Admin-managed announcements/information system';
-COMMENT ON COLUMN announcements.priority IS 'Priority level: normal, important, urgent';
-COMMENT ON COLUMN announcements.group_id IS 'NULL for global announcements, specific group_id for store-specific announcements';
-
 -- Vérification
-SELECT 'Table announcements créée avec succès!' as message;
+SELECT 'Table announcements créée avec succès' as resultat;
+SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'announcements' ORDER BY ordinal_position;

--- a/urgent_production_fix.sh
+++ b/urgent_production_fix.sh
@@ -1,38 +1,19 @@
 #!/bin/bash
-# Script de correction urgente pour la production
-# Exécuter depuis votre serveur de production
+# Script d'urgence pour corriger la production immédiatement
 
-echo "🔧 Correction urgente pour la table announcements..."
+echo "🚨 CORRECTION URGENTE - Création de la table announcements"
 
-# Création de la table via commande SQL directe
-docker exec logiflow-logiflow-1 psql "$DATABASE_URL" -c "
-CREATE TABLE IF NOT EXISTS announcements (
-  id SERIAL PRIMARY KEY,
-  title VARCHAR(255) NOT NULL,
-  content TEXT NOT NULL,
-  priority VARCHAR(20) NOT NULL DEFAULT 'normal' CHECK (priority IN ('normal', 'important', 'urgent')),
-  author_id VARCHAR(255) NOT NULL,
-  group_id INTEGER,
-  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  CONSTRAINT announcements_author_id_fkey FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE,
-  CONSTRAINT announcements_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE
-);
+# Option 1: Copier le fichier SQL dans le conteneur et l'exécuter
+echo "📋 Copie du script SQL dans le conteneur..."
+docker cp create_announcements_production.sql logiflow-logiflow-1:/tmp/
 
-CREATE INDEX IF NOT EXISTS idx_announcements_priority ON announcements(priority);
-CREATE INDEX IF NOT EXISTS idx_announcements_created_at ON announcements(created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_announcements_author_id ON announcements(author_id);
-CREATE INDEX IF NOT EXISTS idx_announcements_group_id ON announcements(group_id);
+echo "🔧 Exécution du script SQL..."
+docker exec logiflow-logiflow-1 psql $DATABASE_URL -f /tmp/create_announcements_production.sql
 
-COMMENT ON TABLE announcements IS 'Admin-managed announcements/information system';
-"
+echo "✅ Script exécuté. Vérification..."
+docker exec logiflow-logiflow-1 psql $DATABASE_URL -c "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name='announcements') as table_exists;"
 
-# Vérification de la création
-echo "🔍 Vérification de la table..."
-docker exec logiflow-logiflow-1 psql "$DATABASE_URL" -c "
-SELECT 'SUCCESS: Table announcements créée!' as status 
-FROM information_schema.tables 
-WHERE table_name = 'announcements';
-"
+echo "🎯 Redémarrage de l'application..."
+docker restart logiflow-logiflow-1
 
-echo "✅ Script terminé!"
+echo "✅ CORRECTION TERMINÉE"


### PR DESCRIPTION
Updates SQL scripts and a bash script to correctly create the `announcements` table in production, resolving a "relation does not exist" error.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: e437ffed-c31b-44eb-9fd5-b6f9faa8e7ce
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/e437ffed-c31b-44eb-9fd5-b6f9faa8e7ce/biGr9ER