### PR TITLE
Update announcement system to use new dashboard messages table

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -49,14 +49,8 @@ if (isProduction && dbUrl && (dbUrl.includes('logiflow-db') || dbUrl.includes('l
   neonConfig.webSocketConstructor = ws.default;
   
   if (dbUrl) {
-    try {
-      pool = new Pool({ connectionString: dbUrl });
-      db = drizzle({ client: pool, schema });
-    } catch (error) {
-      console.error('❌ Neon connection failed, will use MemStorage:', error);
-      pool = null;
-      db = null;
-    }
+    pool = new Pool({ connectionString: dbUrl });
+    db = drizzle({ client: pool, schema });
   } else {
     // Create dummy instances for development
     pool = null;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -10,6 +10,7 @@ import {
   customerOrders,
   dlcProducts,
   tasks,
+  dashboardMessages,
   announcements,
   nocodbConfig,
   invoiceVerificationCache,
@@ -3344,6 +3345,22 @@ export class MemStorage implements IStorage {
       async () => Array.from(this.groups.values())
     );
     return await announcementStorage.getAnnouncements(groupIds);
+  }
+
+  async getAnnouncement(id: number): Promise<AnnouncementWithRelations | undefined> {
+    const announcementStorage = getAnnouncementStorage(
+      async () => Array.from(this.users.values()),
+      async () => Array.from(this.groups.values())
+    );
+    return await announcementStorage.getAnnouncement(id);
+  }
+
+  async updateAnnouncement(id: number, announcementData: Partial<InsertAnnouncement>): Promise<AnnouncementWithRelations> {
+    const announcementStorage = getAnnouncementStorage(
+      async () => Array.from(this.users.values()),
+      async () => Array.from(this.groups.values())
+    );
+    return await announcementStorage.updateAnnouncement(id, announcementData);
   }
 
   async deleteAnnouncement(id: number): Promise<boolean> {


### PR DESCRIPTION
Refactors the announcement storage and schema to utilize the new `dashboard_messages` table, renaming fields like `priority` to `type` and `groupId` to `storeId`, and updating sorting logic to reflect the new type system.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: e437ffed-c31b-44eb-9fd5-b6f9faa8e7ce
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/e437ffed-c31b-44eb-9fd5-b6f9faa8e7ce/VpUPpsj