### PR TITLE
Limit stock depletion button visibility to active products

### DIFF
--- a/client/src/pages/DlcPage.tsx
+++ b/client/src/pages/DlcPage.tsx
@@ -855,8 +855,8 @@ export default function DlcPage() {
                               </Button>
                             )}
                             
-                            {/* Bouton Stock épuisé - accessible à tous */}
-                            {!product.stockEpuise && product.status !== "valides" && (
+                            {/* Bouton Stock épuisé - accessible à tous, seulement pour produits en cours */}
+                            {!product.stockEpuise && product.status === "en_cours" && (
                               <TooltipProvider>
                                 <Tooltip>
                                   <TooltipTrigger asChild>


### PR DESCRIPTION
Hide the stock depletion button for expired or nearing expiration products, ensuring it's only visible for active items.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: f9197b9b-a5b3-4469-a27d-930a9e9ee736
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/f9197b9b-a5b3-4469-a27d-930a9e9ee736/i2gFnxm