### PR TITLE
Prevent deliveries from linking to orders from different stores

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -725,7 +725,13 @@ export class DatabaseStorage implements IStorage {
               .where(eq(orders.id, delivery.orderId));
 
             if (orderData) {
-              associatedOrder = orderData;
+              // CRITICAL FIX: Vérifier que la commande appartient au même magasin que la livraison
+              if (orderData.groupId !== delivery.groupId) {
+                console.error(`❌ PRODUCTION: Delivery #${delivery.id} (store ${delivery.groupId}) linked to order #${delivery.orderId} (store ${orderData.groupId}) - STORE MISMATCH DETECTED!`);
+                // Ne pas inclure la commande si elle n'appartient pas au bon magasin
+              } else {
+                associatedOrder = orderData;
+              }
             }
           } catch (error) {
             console.error(`❌ PRODUCTION: Failed to retrieve associated order #${delivery.orderId} for delivery #${delivery.id}:`, error);
@@ -835,7 +841,13 @@ export class DatabaseStorage implements IStorage {
               .where(eq(orders.id, delivery.orderId));
 
             if (orderData) {
-              associatedOrder = orderData;
+              // CRITICAL FIX: Vérifier que la commande appartient au même magasin que la livraison
+              if (orderData.groupId !== delivery.groupId) {
+                console.error(`❌ PRODUCTION: Delivery #${delivery.id} (store ${delivery.groupId}) linked to order #${delivery.orderId} (store ${orderData.groupId}) - STORE MISMATCH DETECTED!`);
+                // Ne pas inclure la commande si elle n'appartient pas au bon magasin
+              } else {
+                associatedOrder = orderData;
+              }
             }
           } catch (error) {
             console.error(`❌ PRODUCTION: Failed to retrieve associated order #${delivery.orderId} for delivery #${delivery.id}:`, error);
@@ -908,8 +920,14 @@ export class DatabaseStorage implements IStorage {
         console.log(`🔗 PRODUCTION: getDelivery #${id} retrieving associated order #${delivery.orderId}`);
         const orderData = await this.getOrder(delivery.orderId);
         if (orderData) {
-          associatedOrder = orderData;
-          console.log(`✅ PRODUCTION: getDelivery #${id} found associated order #${delivery.orderId} with status: ${orderData.status}`);
+          // CRITICAL FIX: Vérifier que la commande appartient au même magasin que la livraison
+          if (orderData.groupId !== delivery.groupId) {
+            console.error(`❌ PRODUCTION: getDelivery #${id} (store ${delivery.groupId}) linked to order #${delivery.orderId} (store ${orderData.groupId}) - STORE MISMATCH DETECTED!`);
+            // Ne pas inclure la commande si elle n'appartient pas au bon magasin
+          } else {
+            associatedOrder = orderData;
+            console.log(`✅ PRODUCTION: getDelivery #${id} found associated order #${delivery.orderId} with status: ${orderData.status}`);
+          }
         }
       } catch (error) {
         console.error(`❌ PRODUCTION: Failed to retrieve associated order #${delivery.orderId} for delivery #${id}:`, error);


### PR DESCRIPTION
Implement validation to ensure that a delivery is only linked to an order belonging to the same store, preventing cross-store order linking in the delivery module.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 2e1318c6-77b3-4174-b8c7-432d781590ed
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/2e1318c6-77b3-4174-b8c7-432d781590ed/zdg8r7D