### PR TITLE
Order advertisements by their number from smallest to largest

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1209,7 +1209,7 @@ export class DatabaseStorage implements IStorage {
       query = query.where(eq(publicities.year, year));
     }
 
-    const results = await query.orderBy(desc(publicities.pubNumber));
+    const results = await query.orderBy(asc(publicities.pubNumber));
 
     const publicityIds = results.map((p: any) => p.id);
     const participations = publicityIds.length > 0 


### PR DESCRIPTION
Update server/storage.ts to sort publicities by pubNumber in ascending order using asc(publicities.pubNumber).

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 2e1318c6-77b3-4174-b8c7-432d781590ed
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/2e1318c6-77b3-4174-b8c7-432d781590ed/D0szOHB