### PR TITLE
Remove the validation button from the reconciliation modal

### DIFF
--- a/client/src/components/modals/ReconciliationModal.tsx
+++ b/client/src/components/modals/ReconciliationModal.tsx
@@ -86,19 +86,8 @@ export default function ReconciliationModal({
     });
   };
 
-  const handleValidateReconciliation = () => {
-    updateDeliveryMutation.mutate({
-      blNumber: formData.blNumber.trim() || null,
-      blAmount: formData.blAmount ? formData.blAmount.toString() : null,
-      invoiceReference: formData.invoiceReference.trim() || null,
-      invoiceAmount: formData.invoiceAmount ? formData.invoiceAmount.toString() : null,
-      reconciled: true,
-      validatedAt: new Date().toISOString()
-    });
-  };
 
   const isAutomaticMode = delivery?.supplier?.automaticReconciliation;
-  const canValidate = true; // Plus de restriction sur le numéro BL
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -229,15 +218,6 @@ export default function ReconciliationModal({
                 </Button>
               </div>
 
-              <Button
-                type="button"
-                onClick={handleValidateReconciliation}
-                disabled={!canValidate || updateDeliveryMutation.isPending}
-                className="bg-green-600 hover:bg-green-700"
-              >
-                <Check className="w-4 h-4 mr-2 border border-gray-300 rounded p-0.5" />
-                {updateDeliveryMutation.isPending ? "Validation..." : "Valider le rapprochement"}
-              </Button>
             </div>
           </form>
 


### PR DESCRIPTION
Remove the "Valider le rapprochement" button and associated logic from the ReconciliationModal component in client/src/components/modals/ReconciliationModal.tsx.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 72798e04-65c2-4587-bc41-77a3d4984153
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/72798e04-65c2-4587-bc41-77a3d4984153/QaTgrBu