### PR TITLE
Add visual indicator for deliveries linked to orders on the calendar

### DIFF
--- a/client/src/components/CalendarGrid.tsx
+++ b/client/src/components/CalendarGrid.tsx
@@ -1,7 +1,7 @@
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, isSameMonth, isToday } from "date-fns";
 import { fr } from "date-fns/locale";
 import { safeDate } from "@/lib/dateUtils";
-import { Plus, Check, MoreHorizontal, Package } from "lucide-react";
+import { Plus, Check, MoreHorizontal, Package, Link } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { useState } from "react";
@@ -87,7 +87,13 @@ function CalendarItem({ item, type, onItemClick }: { item: any, type: 'order' | 
         <span className="truncate font-semibold" style={{fontSize: '11px', lineHeight: '1.2'}}>
           {item.supplier?.name || 'Livraison'} - {formatQuantity(item.quantity, item.unit)}
         </span>
-        <div style={{display: 'flex', alignItems: 'center', marginLeft: '4px'}}>
+        <div style={{display: 'flex', alignItems: 'center', gap: '4px', marginLeft: '4px'}}>
+          {/* Badge pour livraison liée à une commande */}
+          {item.orderId && (
+            <div className="w-4 h-4 bg-blue-500 rounded-full flex items-center justify-center" title="Liée à une commande">
+              <Link className="w-2 h-2 text-white" />
+            </div>
+          )}
           {item.status === 'pending' && (
             <div className="w-2 h-2 bg-green-600 rounded-full" title="En attente" />
           )}


### PR DESCRIPTION
Imports the `Link` icon from `lucide-react` and adds a conditional badge displaying a link icon to `CalendarItem` components when `item.orderId` is present, indicating a delivery linked to an order.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 98f01874-e00c-4bbe-9d71-b0b338001848
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/98f01874-e00c-4bbe-9d71-b0b338001848/PAgei8r