### PR TITLE
Add visual indicator for orders linked to deliveries

### DIFF
--- a/client/src/components/CalendarGrid.tsx
+++ b/client/src/components/CalendarGrid.tsx
@@ -49,7 +49,13 @@ function CalendarItem({ item, type, onItemClick }: { item: any, type: 'order' | 
           <span className="truncate font-semibold" style={{fontSize: '11px', lineHeight: '1.2'}}>
             {item.supplier?.name || 'Commande'}
           </span>
-          <div style={{display: 'flex', alignItems: 'center', marginLeft: '4px'}}>
+          <div style={{display: 'flex', alignItems: 'center', gap: '4px', marginLeft: '4px'}}>
+            {/* Badge pour commande liée à des livraisons */}
+            {item.deliveries && item.deliveries.length > 0 && (
+              <div className="w-4 h-4 bg-blue-500 rounded-full flex items-center justify-center" title="Liée à des livraisons">
+                <Link className="w-2 h-2 text-white" />
+              </div>
+            )}
             {item.status === 'planned' && (
               <div className="w-2 h-2 bg-yellow-600 rounded-full" title="Planifié" />
             )}


### PR DESCRIPTION
Adds a blue badge to `CalendarItem` component in `CalendarGrid.tsx` to visually indicate when an order is linked to deliveries, utilizing a `Link` icon and styling.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 98f01874-e00c-4bbe-9d71-b0b338001848
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/98f01874-e00c-4bbe-9d71-b0b338001848/HSHfb0Z