### PR TITLE
Show linkage badges on daily delivery and order items

### DIFF
--- a/client/src/components/CalendarGrid.tsx
+++ b/client/src/components/CalendarGrid.tsx
@@ -211,6 +211,14 @@ function DayItemsContainer({ dayOrders, dayDeliveries, onItemClick }: { dayOrder
                             <span className="text-xs font-medium text-gray-600 uppercase">
                               {isOrder ? 'COMMANDE' : 'LIVRAISON'}
                             </span>
+                            {/* Badge pour liaison - commandes avec livraisons ou livraisons avec commandes */}
+                            {((isOrder && item.deliveries && item.deliveries.length > 0) || 
+                              (!isOrder && item.orderId)) && (
+                              <div className="w-4 h-4 bg-blue-500 rounded-full flex items-center justify-center" 
+                                   title={isOrder ? "Liée à des livraisons" : "Liée à une commande"}>
+                                <Link className="w-2 h-2 text-white" />
+                              </div>
+                            )}
                             <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${
                               item.status === 'delivered' ? 'bg-gray-200 text-gray-700' :
                               item.status === 'planned' ? 'bg-yellow-200 text-yellow-800' :


### PR DESCRIPTION
Add conditional rendering for linkage badges in `CalendarGrid.tsx` when an order has deliveries or a delivery is associated with an order.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 98f01874-e00c-4bbe-9d71-b0b338001848
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/98f01874-e00c-4bbe-9d71-b0b338001848/747GbQM