### PR TITLE
Update dashboard to show only pending orders older than 10 days

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -237,7 +237,16 @@ export default function Dashboard() {
   console.log('🚚 Dashboard - Upcoming deliveries result:', upcomingDeliveries.length, upcomingDeliveries);
 
   // Calculs pour les statistiques
-  const pendingOrdersCount = Array.isArray(allOrders) ? allOrders.filter((order: any) => order.status === 'pending').length : 0;
+  const pendingOrdersCount = Array.isArray(allOrders) ? allOrders.filter((order: any) => {
+    if (order.status !== 'pending') return false;
+    
+    // Vérifier si la commande est en pending depuis plus de 10 jours
+    const orderDate = safeDate(order.createdAt);
+    if (!orderDate) return false;
+    
+    const daysDiff = Math.floor((new Date().getTime() - orderDate.getTime()) / (1000 * 60 * 60 * 24));
+    return daysDiff > 10;
+  }).length : 0;
   const averageDeliveryTime = Math.round(stats?.averageDeliveryTime || 0);
   const deliveredThisMonth = Array.isArray(allDeliveries) ? allDeliveries.filter((delivery: any) => {
     const deliveryDate = safeDate(delivery.deliveredDate || delivery.createdAt);


### PR DESCRIPTION
Modify the dashboard logic to filter and display only 'pending' orders that were created more than 10 days ago, based on the order's `createdAt` timestamp.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 98f01874-e00c-4bbe-9d71-b0b338001848
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/98f01874-e00c-4bbe-9d71-b0b338001848/XDIQsDu