### PR TITLE
Limit pending orders displayed and add scrolling functionality

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -225,14 +225,15 @@ export default function Dashboard() {
     })
     .slice(0, 4) : []; // Afficher les 4 dernières commandes
 
-  // Toutes les commandes en attente (peu importe la date)
+  // Les 4 dernières commandes en attente
   const pendingOrders = Array.isArray(allOrders) ? allOrders
     .filter((order: any) => order.status === 'pending')
     .sort((a: any, b: any) => {
       const dateA = safeDate(a.createdAt);
       const dateB = safeDate(b.createdAt);
       return (dateB ? dateB.getTime() : 0) - (dateA ? dateA.getTime() : 0);
-    }) : [];
+    })
+    .slice(0, 4) : []; // Afficher les 4 dernières commandes en attente
   
   const upcomingDeliveries = Array.isArray(allDeliveries) ? allDeliveries
     .filter((d: any) => {
@@ -453,7 +454,7 @@ export default function Dashboard() {
               )}
             </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-3 p-6">
+          <CardContent className="space-y-3 p-6 max-h-96 overflow-y-auto">
             {pendingOrders.length > 0 ? pendingOrders.map((order: any) => {
               // Calculer le nombre de jours en attente
               const orderDate = safeDate(order.createdAt);


### PR DESCRIPTION
Updates the dashboard to display only the last 4 pending orders and implements vertical scrolling for the pending orders section within `Dashboard.tsx`.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 98f01874-e00c-4bbe-9d71-b0b338001848
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/98f01874-e00c-4bbe-9d71-b0b338001848/XDIQsDu