### PR TITLE
Improve filtering for suppliers based on DLC status

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -211,8 +211,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // Check if DLC filter is requested
+      const dlcFilter = req.query.dlc === 'true';
       const suppliers = await storage.getSuppliers();
-      res.json(suppliers);
+      
+      // Filter suppliers for DLC enabled only if requested
+      if (dlcFilter) {
+        const dlcSuppliers = suppliers.filter(supplier => supplier.dlcEnabled === true);
+        res.json(dlcSuppliers);
+      } else {
+        res.json(suppliers);
+      }
     } catch (error) {
       console.error("Error fetching suppliers:", error);
       res.status(500).json({ message: "Failed to fetch suppliers" });


### PR DESCRIPTION
Correctly filter suppliers to only show DLC-enabled ones when the DLC filter is applied in the API.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: f2b9c241-9fdd-4abd-9041-720afc8b27d6
Replit-Commit-Checkpoint-Type: full_checkpoint