### PR TITLE
Update dashboard to display yearly delivery statistics

### DIFF
--- a/.replit
+++ b/.replit
@@ -37,4 +37,4 @@ args = "npm run dev"
 waitForPort = 5000
 
 [agent]
-integrations = ["javascript_log_in_with_replit==1.0.0", "javascript_object_storage==1.0.0", "javascript_database==1.0.0"]
+integrations = ["javascript_database==1.0.0", "javascript_log_in_with_replit==1.0.0", "javascript_object_storage==1.0.0"]

--- a/client/src/components/StatsPanel.tsx
+++ b/client/src/components/StatsPanel.tsx
@@ -14,8 +14,8 @@ export default function StatsPanel({ currentDate = new Date() }: StatsPanelProps
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth() + 1;
 
-  // Construire l'URL avec les paramètres
-  const statsUrl = `/api/stats/monthly?year=${year}&month=${month}${selectedStoreId ? `&storeId=${selectedStoreId}` : ''}`;
+  // Construire l'URL pour les statistiques annuelles
+  const statsUrl = `/api/stats/yearly?year=${year}${selectedStoreId ? `&storeId=${selectedStoreId}` : ''}`;
 
   const { data: stats, isLoading } = useQuery({
     queryKey: [statsUrl, selectedStoreId], // Include selectedStoreId in key to force refetch
@@ -25,7 +25,7 @@ export default function StatsPanel({ currentDate = new Date() }: StatsPanelProps
       });
       
       if (!response.ok) {
-        throw new Error('Failed to fetch stats');
+        throw new Error('Failed to fetch yearly stats');
       }
       
       return response.json();
@@ -55,7 +55,7 @@ export default function StatsPanel({ currentDate = new Date() }: StatsPanelProps
       <CardHeader className="pb-3">
         <CardTitle className="text-lg flex items-center">
           <TrendingUp className="w-5 h-5 text-accent mr-2" />
-          Statistiques du mois
+          Statistiques de l'année
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -91,7 +91,7 @@ export default function StatsPanel({ currentDate = new Date() }: StatsPanelProps
         <div className="mt-3 pt-3 border-t border-gray-200 text-center">
           <div className="text-sm text-gray-600 flex items-center justify-center">
             <Clock className="w-4 h-4 mr-1" />
-            Délai moyen: 
+            Délai commande → livraison: 
             <span className="font-medium text-gray-900 ml-1">
               {stats?.averageDeliveryTime?.toFixed(1) || '0'} jours
             </span>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2337,6 +2337,42 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Route pour les statistiques annuelles
+  app.get('/api/stats/yearly', isAuthenticated, async (req: any, res) => {
+    try {
+      const user = await storage.getUserWithGroups(req.user.claims ? req.user.claims.sub : req.user.id);
+      if (!user) {
+        return res.status(404).json({ message: "User not found" });
+      }
+
+      const { year, storeId } = req.query;
+      const currentYear = year ? parseInt(year as string) : new Date().getFullYear();
+
+      let groupIds: number[] | undefined;
+      
+      if (user.role === 'admin') {
+        // Admin can view all stores or filter by selected store
+        groupIds = storeId ? [parseInt(storeId as string)] : undefined;
+      } else {
+        // Non-admin users: filter by their assigned groups
+        const userGroupIds = user.userGroups.map(ug => ug.groupId);
+        
+        // If a specific store is selected and user has access, filter by it
+        if (storeId && userGroupIds.includes(parseInt(storeId as string))) {
+          groupIds = [parseInt(storeId as string)];
+        } else {
+          groupIds = userGroupIds;
+        }
+      }
+
+      const stats = await storage.getYearlyStats(currentYear, groupIds);
+      res.json(stats);
+    } catch (error) {
+      console.error("Error fetching yearly stats:", error);
+      res.status(500).json({ message: "Failed to fetch yearly statistics" });
+    }
+  });
+
   // User-Group management routes (admin only)
   app.post('/api/users/:userId/groups', isAuthenticated, async (req: any, res) => {
     try {


### PR DESCRIPTION
Introduce a new API endpoint '/api/stats/yearly' for fetching annual statistics and update the StatsPanel component to use this endpoint, changing the card title to "Statistiques de l'année" and the average delivery time label to "Délai commande → livraison".

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: cfbfe47c-0c9a-4ebf-8a41-2937407eccff
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/cfbfe47c-0c9a-4ebf-8a41-2937407eccff/9qfOTfC