### PR TITLE
Update dashboard to display yearly delivery times and monthly stats

### DIFF
--- a/.replit
+++ b/.replit
@@ -37,4 +37,4 @@ args = "npm run dev"
 waitForPort = 5000
 
 [agent]
-integrations = ["javascript_database==1.0.0", "javascript_log_in_with_replit==1.0.0", "javascript_object_storage==1.0.0"]
+integrations = ["javascript_database==1.0.0", "javascript_object_storage==1.0.0", "javascript_log_in_with_replit==1.0.0"]

--- a/client/src/components/StatsPanel.tsx
+++ b/client/src/components/StatsPanel.tsx
@@ -14,8 +14,8 @@ export default function StatsPanel({ currentDate = new Date() }: StatsPanelProps
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth() + 1;
 
-  // Construire l'URL pour les statistiques annuelles
-  const statsUrl = `/api/stats/yearly?year=${year}${selectedStoreId ? `&storeId=${selectedStoreId}` : ''}`;
+  // Construire l'URL avec les paramètres
+  const statsUrl = `/api/stats/monthly?year=${year}&month=${month}${selectedStoreId ? `&storeId=${selectedStoreId}` : ''}`;
 
   const { data: stats, isLoading } = useQuery({
     queryKey: [statsUrl, selectedStoreId], // Include selectedStoreId in key to force refetch
@@ -25,7 +25,7 @@ export default function StatsPanel({ currentDate = new Date() }: StatsPanelProps
       });
       
       if (!response.ok) {
-        throw new Error('Failed to fetch yearly stats');
+        throw new Error('Failed to fetch stats');
       }
       
       return response.json();
@@ -55,7 +55,7 @@ export default function StatsPanel({ currentDate = new Date() }: StatsPanelProps
       <CardHeader className="pb-3">
         <CardTitle className="text-lg flex items-center">
           <TrendingUp className="w-5 h-5 text-accent mr-2" />
-          Statistiques de l'année
+          Statistiques du mois
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -91,7 +91,7 @@ export default function StatsPanel({ currentDate = new Date() }: StatsPanelProps
         <div className="mt-3 pt-3 border-t border-gray-200 text-center">
           <div className="text-sm text-gray-600 flex items-center justify-center">
             <Clock className="w-4 h-4 mr-1" />
-            Délai commande → livraison: 
+            Délai moyen: 
             <span className="font-medium text-gray-900 ml-1">
               {stats?.averageDeliveryTime?.toFixed(1) || '0'} jours
             </span>


### PR DESCRIPTION
Modify the StatsPanel component to fetch and display monthly statistics instead of yearly. Adjust the Dashboard component to fetch and display yearly average delivery times in the 'Average Delivery Time' card.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: cfbfe47c-0c9a-4ebf-8a41-2937407eccff
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/cfbfe47c-0c9a-4ebf-8a41-2937407eccff/sQhaOQu