### PR TITLE
Update the credits section to make reference and amount optional

### DIFF
--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -256,6 +256,12 @@ export default function Sidebar() {
       roles: ["admin", "directeur"] 
     },
     { 
+      path: "/avoirs", 
+      label: "Avoirs", 
+      icon: Receipt, 
+      roles: ["admin", "directeur", "manager"] 
+    },
+    { 
       path: "/publicities", 
       label: "Publicités", 
       icon: Megaphone, 
@@ -284,12 +290,6 @@ export default function Sidebar() {
       label: "SAV", 
       icon: Wrench, 
       roles: ["admin", "directeur", "manager", "employee"] 
-    },
-    { 
-      path: "/avoirs", 
-      label: "Avoirs", 
-      icon: Receipt, 
-      roles: ["admin", "directeur", "manager"] 
     },
   ];
 

--- a/client/src/pages/Avoirs.tsx
+++ b/client/src/pages/Avoirs.tsx
@@ -69,8 +69,8 @@ interface Group {
 const avoirSchema = z.object({
   supplierId: z.number().min(1, "Veuillez sélectionner un fournisseur"),
   groupId: z.number().min(1, "Veuillez sélectionner un magasin"),
-  invoiceReference: z.string().min(1, "La référence facture est requise"),
-  amount: z.number().min(0.01, "Le montant doit être supérieur à 0"),
+  invoiceReference: z.string().optional(),
+  amount: z.number().optional(),
   comment: z.string().optional(),
   commercialProcessed: z.boolean().optional(),
 });
@@ -148,7 +148,7 @@ export default function Avoirs() {
       supplierId: 0,
       groupId: 0,
       invoiceReference: "",
-      amount: 0,
+      amount: undefined,
       comment: "",
       commercialProcessed: false,
     },
@@ -296,7 +296,7 @@ export default function Avoirs() {
                   name="invoiceReference"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Référence facture</FormLabel>
+                      <FormLabel>Référence facture (optionnel)</FormLabel>
                       <FormControl>
                         <Input placeholder="Numéro de facture" {...field} />
                       </FormControl>
@@ -310,14 +310,14 @@ export default function Avoirs() {
                   name="amount"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Montant (€)</FormLabel>
+                      <FormLabel>Montant (€) (optionnel)</FormLabel>
                       <FormControl>
                         <Input 
                           type="number" 
                           step="0.01" 
                           placeholder="0.00"
                           {...field}
-                          onChange={(e) => field.onChange(parseFloat(e.target.value) || 0)}
+                          onChange={(e) => field.onChange(e.target.value ? parseFloat(e.target.value) : undefined)}
                         />
                       </FormControl>
                       <FormMessage />


### PR DESCRIPTION
Modify the client-side schema and UI for the "Avoirs" page to make "invoiceReference" and "amount" fields optional, and reposition the "Avoirs" link in the sidebar.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869/0C3uBiZ