### PR TITLE
Improve data refreshing in the task management module

### DIFF
--- a/client/src/pages/Avoirs.tsx
+++ b/client/src/pages/Avoirs.tsx
@@ -156,7 +156,12 @@ export default function Avoirs() {
       return response.json();
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/avoirs'] });
+      // ✅ FIX: Invalider toutes les variations de queryKey avoirs
+      queryClient.invalidateQueries({ 
+        predicate: (query) => {
+          return query.queryKey[0]?.toString().includes('/api/avoirs');
+        }
+      });
       setIsCreateDialogOpen(false);
       toast({
         title: "Avoir créé",
@@ -189,7 +194,12 @@ export default function Avoirs() {
       return response.json();
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/avoirs'] });
+      // ✅ FIX: Invalider toutes les variations de queryKey avoirs
+      queryClient.invalidateQueries({ 
+        predicate: (query) => {
+          return query.queryKey[0]?.toString().includes('/api/avoirs');
+        }
+      });
       setIsEditDialogOpen(false);
       setSelectedAvoir(null);
       toast({
@@ -219,7 +229,12 @@ export default function Avoirs() {
       return response.json();
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['/api/avoirs'] });
+      // ✅ FIX: Invalider toutes les variations de queryKey avoirs
+      queryClient.invalidateQueries({ 
+        predicate: (query) => {
+          return query.queryKey[0]?.toString().includes('/api/avoirs');
+        }
+      });
       setIsDeleteDialogOpen(false);
       setSelectedAvoir(null);
       toast({


### PR DESCRIPTION
Update React Query cache invalidation to properly refresh all Avoirs data variations after modifications, resolving the need for manual page reloads.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869/lmbX0S1