### PR TITLE
Send credit note details via webhook when status changes to received

### DIFF
--- a/client/src/pages/Avoirs.tsx
+++ b/client/src/pages/Avoirs.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Plus, Search, FileText, CheckCircle, AlertCircle, Clock, Edit, Trash2, UserCheck } from "lucide-react";
+import { Plus, Search, FileText, CheckCircle, AlertCircle, Clock, Edit, Trash2, UserCheck, Send } from "lucide-react";
 import { useStore } from "@/components/Layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -159,7 +159,7 @@ export default function Avoirs() {
       // ✅ FIX: Invalider toutes les variations de queryKey avoirs
       queryClient.invalidateQueries({ 
         predicate: (query) => {
-          return query.queryKey[0]?.toString().includes('/api/avoirs');
+          return query.queryKey[0]?.toString().includes('/api/avoirs') || false;
         }
       });
       setIsCreateDialogOpen(false);
@@ -197,7 +197,7 @@ export default function Avoirs() {
       // ✅ FIX: Invalider toutes les variations de queryKey avoirs
       queryClient.invalidateQueries({ 
         predicate: (query) => {
-          return query.queryKey[0]?.toString().includes('/api/avoirs');
+          return query.queryKey[0]?.toString().includes('/api/avoirs') || false;
         }
       });
       setIsEditDialogOpen(false);
@@ -232,7 +232,7 @@ export default function Avoirs() {
       // ✅ FIX: Invalider toutes les variations de queryKey avoirs
       queryClient.invalidateQueries({ 
         predicate: (query) => {
-          return query.queryKey[0]?.toString().includes('/api/avoirs');
+          return query.queryKey[0]?.toString().includes('/api/avoirs') || false;
         }
       });
       setIsDeleteDialogOpen(false);
@@ -658,6 +658,11 @@ export default function Avoirs() {
                           {avoir.commercialProcessed && (
                             <div title="Avoir fait par commercial">
                               <UserCheck className="h-4 w-4 text-blue-600 ml-2" />
+                            </div>
+                          )}
+                          {avoir.webhookSent && (
+                            <div title="Webhook envoyé">
+                              <Send className="h-4 w-4 text-green-600 ml-2" />
                             </div>
                           )}
                         </div>


### PR DESCRIPTION
Implement webhook functionality to send credit note information to configured groups when the status is updated to 'Reçu'. The webhook payload includes credit note details, sender information, and group details. Default group ID is set to 1 for administrators if not specified. Also, adds a visual indicator for sent webhooks on the frontend.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869/liv4dfe