### PR TITLE
Allow negative amounts to be processed in credit notes

### DIFF
--- a/client/src/pages/Avoirs.tsx
+++ b/client/src/pages/Avoirs.tsx
@@ -80,6 +80,10 @@ const avoirSchema = z.object({
     z.null().transform(() => undefined),
     z.undefined().transform(() => undefined), 
     z.literal("").transform(() => undefined),
+    z.number().transform((num) => {
+      // Permettre tous les nombres existants (positifs, négatifs, zéro)
+      return num;
+    }),
     z.string().transform((val) => {
       if (val.trim() === '') return undefined; // Permettre les champs vides
       const num = parseFloat(val);
@@ -397,7 +401,7 @@ export default function Avoirs() {
       supplierId: avoir.supplierId || 0,
       groupId: avoir.groupId || 0,
       invoiceReference: avoir.invoiceReference || "",
-      amount: avoir.amount,
+      amount: avoir.amount ?? undefined, // ✅ Convertir null en undefined pour permettre la suppression
       comment: avoir.comment || "",
       commercialProcessed: avoir.commercialProcessed || false,
       status: avoir.status || "En attente de demande",


### PR DESCRIPTION
Update the credit note schema to accept all numeric values (positive, negative, zero) and handle null amounts by converting them to undefined.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869/Ii96ETr