### PR TITLE
Fix issue preventing users from deleting numeric input values

### DIFF
--- a/client/src/pages/Avoirs.tsx
+++ b/client/src/pages/Avoirs.tsx
@@ -1361,9 +1361,21 @@ export default function Avoirs() {
                         type="number" 
                         step="0.01" 
                         placeholder="Montant en euros (optionnel)" 
-                        {...field}
                         value={field.value ?? ""}
-                        onChange={(e) => field.onChange(e.target.value ? parseFloat(e.target.value) : undefined)}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          if (value === "") {
+                            field.onChange(undefined);
+                          } else {
+                            const num = parseFloat(value);
+                            if (!isNaN(num)) {
+                              field.onChange(num);
+                            }
+                          }
+                        }}
+                        onBlur={field.onBlur}
+                        name={field.name}
+                        ref={field.ref}
                       />
                     </FormControl>
                     <FormMessage />


### PR DESCRIPTION
Corrected the numeric input onChange handler in Avoirs.tsx to properly handle empty string input and non-numeric values, allowing users to clear the input field.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869/Ii96ETr