### PR TITLE
Prevent changing status for validated invoices and disable selection

### DIFF
--- a/client/src/pages/Avoirs.tsx
+++ b/client/src/pages/Avoirs.tsx
@@ -458,6 +458,18 @@ export default function Avoirs() {
 
   // Handle status change
   const handleStatusChange = (avoirId: number, newStatus: string) => {
+    const avoir = avoirs?.find(a => a?.id === avoirId);
+    
+    // Empêcher la modification du statut pour les avoirs validés
+    if (avoir?.nocodbVerified) {
+      toast({
+        title: "Modification interdite",
+        description: "Impossible de modifier le statut d'un avoir validé",
+        variant: "destructive",
+      });
+      return;
+    }
+    
     // Empêcher les managers de mettre le statut en "Reçu"
     if ((user as any)?.role === 'manager' && newStatus === 'Reçu') {
       toast({
@@ -467,8 +479,6 @@ export default function Avoirs() {
       });
       return;
     }
-
-    const avoir = avoirs?.find(a => a?.id === avoirId);
     if (avoir && avoir.supplierId && avoir.groupId) {
       editAvoirMutation.mutate({ 
         id: avoirId, 
@@ -984,8 +994,9 @@ export default function Avoirs() {
                   <Select 
                     value={avoir?.status || ''}
                     onValueChange={(newStatus) => handleStatusChange(avoir.id, newStatus)}
+                    disabled={avoir.nocodbVerified}
                   >
-                    <SelectTrigger className="w-full">
+                    <SelectTrigger className={`w-full ${avoir.nocodbVerified ? 'opacity-50 cursor-not-allowed' : ''}`}>
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>


### PR DESCRIPTION
Add validation to prevent users from changing the status of an invoice once it has been validated. The UI for validated invoices is also updated to be disabled and visually indicate its non-editable state.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869/yiEpJFx