### PR TITLE
Fix task display issue for directors on initial page load

### DIFF
--- a/client/src/pages/Tasks.tsx
+++ b/client/src/pages/Tasks.tsx
@@ -384,7 +384,7 @@ export default function Tasks() {
         throw error;
       }
     },
-    enabled: !!user && (user.role !== 'admin' || storeInitialized),
+    enabled: !!user && (user.role === 'admin' || user.role === 'directeur' ? storeInitialized : true),
   });
 
   // Fetch users for task assignment - seulement pour admin/manager/directeur


### PR DESCRIPTION
Update task fetching logic to correctly enable data retrieval for 'directeur' role users, resolving an issue where tasks were not displayed until a page refresh.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869/yiEpJFx