### PR TITLE
Improve task display for director role by enabling data fetching

### DIFF
--- a/client/src/pages/Tasks.tsx
+++ b/client/src/pages/Tasks.tsx
@@ -346,7 +346,9 @@ export default function Tasks() {
           userRole: user?.role,
           storeInitialized,
           url: `/api/tasks?${params.toString()}`,
-          willFilterByStore: !!selectedStoreId
+          willFilterByStore: !!selectedStoreId,
+          enabled: !!user,
+          timestamp: new Date().toISOString()
         });
         
         const response = await fetch(`/api/tasks?${params.toString()}`, {
@@ -384,7 +386,7 @@ export default function Tasks() {
         throw error;
       }
     },
-    enabled: !!user && (user.role === 'admin' || user.role === 'directeur' ? storeInitialized : true),
+    enabled: !!user,
   });
 
   // Fetch users for task assignment - seulement pour admin/manager/directeur


### PR DESCRIPTION
Update Tasks.tsx to correctly enable data fetching for director role, ensuring tasks are displayed without manual page reloads. The `enabled` flag in the `useQuery` hook is now set to `!!user` for the tasks query, and the filter logic for `user.role` has been removed.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/9fcf4b21-eb0c-4e53-a567-e2ce4a6ad869/yiEpJFx