### PR TITLE
Adjust sidebar spacing to fix display issue on desktop

### DIFF
--- a/.replit
+++ b/.replit
@@ -16,7 +16,7 @@ localPort = 5000
 externalPort = 80
 
 [[ports]]
-localPort = 45105
+localPort = 45995
 externalPort = 3000
 
 [workflows]

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -132,10 +132,8 @@ export default function Layout({ children }: LayoutProps) {
         <Sidebar />
         
         <main className={`flex-1 flex flex-col h-full ${
-          // Ajuster la marge gauche selon la taille de l'écran et l'état de la sidebar
-          isMobile ? 'ml-0' : 
-          isTablet ? (sidebarCollapsed ? 'ml-16' : 'ml-48') : 
-          (sidebarCollapsed ? 'ml-16' : 'ml-64')
+          // Marge gauche uniquement si la sidebar est en position fixed (tablet expanded)
+          isMobile ? 'ml-0' : (isTablet && !sidebarCollapsed) ? 'ml-48' : 'ml-0'
         }`}>
           {/* Header with mobile menu and store selector */}
           <header className={`h-16 bg-white border-b border-gray-200 flex items-center justify-between ${


### PR DESCRIPTION
Update Layout component to conditionally apply left margin to main content based on screen size and sidebar state, specifically fixing a large empty space on desktop when the sidebar is not collapsed.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 95e8aab4-f39f-4b48-aa57-a759ec15ba3d
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/95e8aab4-f39f-4b48-aa57-a759ec15ba3d/E90Hfqm