### PR TITLE
Fix issue where deliveries show orders from incorrect stores

### DIFF
--- a/.replit
+++ b/.replit
@@ -31,6 +31,10 @@ externalPort = 3002
 localPort = 41343
 externalPort = 3001
 
+[[ports]]
+localPort = 41735
+externalPort = 4200
+
 [workflows]
 runButton = "Project"
 

--- a/backups/backup_automatic_2025-09-23T08-42-36-690Z.sql
+++ b/backups/backup_automatic_2025-09-23T08-42-36-690Z.sql
@@ -2,10 +2,10 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 16.9 (84ade85)
+-- Dumped from database version 16.9 (63f4182)
 -- Dumped by pg_dump version 16.9
 
--- Started on 2025-09-11 05:59:54 UTC
+-- Started on 2025-09-23 08:42:36 UTC
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -20,7 +20,7 @@ SET row_security = off;
 
 DROP DATABASE IF EXISTS neondb;
 --
--- TOC entry 3829 (class 1262 OID 16389)
+-- TOC entry 3845 (class 1262 OID 16389)
 -- Name: neondb; Type: DATABASE; Schema: -; Owner: neondb_owner
 --
 
@@ -67,7 +67,7 @@ CREATE TABLE public.announcements (
 ALTER TABLE public.announcements OWNER TO neondb_owner;
 
 --
--- TOC entry 3831 (class 0 OID 0)
+-- TOC entry 3847 (class 0 OID 0)
 -- Dependencies: 272
 -- Name: TABLE announcements; Type: COMMENT; Schema: public; Owner: neondb_owner
 --
@@ -76,7 +76,7 @@ COMMENT ON TABLE public.announcements IS 'Admin-managed announcements/informatio
 
 
 --
--- TOC entry 3832 (class 0 OID 0)
+-- TOC entry 3848 (class 0 OID 0)
 -- Dependencies: 272
 -- Name: COLUMN announcements.priority; Type: COMMENT; Schema: public; Owner: neondb_owner
 --
@@ -85,7 +85,7 @@ COMMENT ON COLUMN public.announcements.priority IS 'Priority level: normal, impo
 
 
 --
--- TOC entry 3833 (class 0 OID 0)
+-- TOC entry 3849 (class 0 OID 0)
 -- Dependencies: 272
 -- Name: COLUMN announcements.group_id; Type: COMMENT; Schema: public; Owner: neondb_owner
 --
@@ -110,7 +110,7 @@ CREATE SEQUENCE public.announcements_id_seq
 ALTER SEQUENCE public.announcements_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3834 (class 0 OID 0)
+-- TOC entry 3850 (class 0 OID 0)
 -- Dependencies: 271
 -- Name: announcements_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -161,7 +161,7 @@ CREATE SEQUENCE public.avoirs_id_seq
 ALTER SEQUENCE public.avoirs_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3835 (class 0 OID 0)
+-- TOC entry 3851 (class 0 OID 0)
 -- Dependencies: 275
 -- Name: avoirs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -209,7 +209,7 @@ CREATE SEQUENCE public.calendar_events_id_seq
 ALTER SEQUENCE public.calendar_events_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3836 (class 0 OID 0)
+-- TOC entry 3852 (class 0 OID 0)
 -- Dependencies: 215
 -- Name: calendar_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -256,7 +256,7 @@ CREATE SEQUENCE public.client_orders_id_seq
 ALTER SEQUENCE public.client_orders_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3837 (class 0 OID 0)
+-- TOC entry 3853 (class 0 OID 0)
 -- Dependencies: 217
 -- Name: client_orders_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -300,7 +300,7 @@ CREATE SEQUENCE public.command_items_id_seq
 ALTER SEQUENCE public.command_items_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3838 (class 0 OID 0)
+-- TOC entry 3854 (class 0 OID 0)
 -- Dependencies: 219
 -- Name: command_items_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -348,7 +348,7 @@ CREATE SEQUENCE public.commands_id_seq
 ALTER SEQUENCE public.commands_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3839 (class 0 OID 0)
+-- TOC entry 3855 (class 0 OID 0)
 -- Dependencies: 221
 -- Name: commands_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -403,7 +403,7 @@ CREATE SEQUENCE public.customer_orders_id_seq
 ALTER SEQUENCE public.customer_orders_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3840 (class 0 OID 0)
+-- TOC entry 3856 (class 0 OID 0)
 -- Dependencies: 246
 -- Name: customer_orders_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -448,7 +448,7 @@ CREATE SEQUENCE public.customers_id_seq
 ALTER SEQUENCE public.customers_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3841 (class 0 OID 0)
+-- TOC entry 3857 (class 0 OID 0)
 -- Dependencies: 223
 -- Name: customers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -491,7 +491,7 @@ CREATE SEQUENCE public.dashboard_messages_id_seq
 ALTER SEQUENCE public.dashboard_messages_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3842 (class 0 OID 0)
+-- TOC entry 3858 (class 0 OID 0)
 -- Dependencies: 267
 -- Name: dashboard_messages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -567,7 +567,7 @@ CREATE SEQUENCE public.deliveries_id_seq
 ALTER SEQUENCE public.deliveries_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3843 (class 0 OID 0)
+-- TOC entry 3859 (class 0 OID 0)
 -- Dependencies: 258
 -- Name: deliveries_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -611,7 +611,7 @@ CREATE SEQUENCE public.delivery_items_id_seq
 ALTER SEQUENCE public.delivery_items_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3844 (class 0 OID 0)
+-- TOC entry 3860 (class 0 OID 0)
 -- Dependencies: 225
 -- Name: delivery_items_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -657,7 +657,7 @@ CREATE TABLE public.dlc_products (
 ALTER TABLE public.dlc_products OWNER TO neondb_owner;
 
 --
--- TOC entry 3845 (class 0 OID 0)
+-- TOC entry 3861 (class 0 OID 0)
 -- Dependencies: 249
 -- Name: COLUMN dlc_products.stock_epuise; Type: COMMENT; Schema: public; Owner: neondb_owner
 --
@@ -666,7 +666,7 @@ COMMENT ON COLUMN public.dlc_products.stock_epuise IS 'Indique si le produit est
 
 
 --
--- TOC entry 3846 (class 0 OID 0)
+-- TOC entry 3862 (class 0 OID 0)
 -- Dependencies: 249
 -- Name: COLUMN dlc_products.stock_epuise_by; Type: COMMENT; Schema: public; Owner: neondb_owner
 --
@@ -675,7 +675,7 @@ COMMENT ON COLUMN public.dlc_products.stock_epuise_by IS 'ID de l''utilisateur q
 
 
 --
--- TOC entry 3847 (class 0 OID 0)
+-- TOC entry 3863 (class 0 OID 0)
 -- Dependencies: 249
 -- Name: COLUMN dlc_products.stock_epuise_at; Type: COMMENT; Schema: public; Owner: neondb_owner
 --
@@ -700,7 +700,7 @@ CREATE SEQUENCE public.dlc_products_id_seq
 ALTER SEQUENCE public.dlc_products_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3848 (class 0 OID 0)
+-- TOC entry 3864 (class 0 OID 0)
 -- Dependencies: 248
 -- Name: dlc_products_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -752,7 +752,7 @@ CREATE SEQUENCE public.groups_id_seq
 ALTER SEQUENCE public.groups_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3849 (class 0 OID 0)
+-- TOC entry 3865 (class 0 OID 0)
 -- Dependencies: 236
 -- Name: groups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -804,7 +804,7 @@ CREATE SEQUENCE public.invoice_verification_cache_id_seq
 ALTER SEQUENCE public.invoice_verification_cache_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3850 (class 0 OID 0)
+-- TOC entry 3866 (class 0 OID 0)
 -- Dependencies: 265
 -- Name: invoice_verification_cache_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -850,7 +850,7 @@ CREATE SEQUENCE public.invoice_verifications_id_seq
 ALTER SEQUENCE public.invoice_verifications_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3851 (class 0 OID 0)
+-- TOC entry 3867 (class 0 OID 0)
 -- Dependencies: 263
 -- Name: invoice_verifications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -899,7 +899,7 @@ CREATE SEQUENCE public.invoices_id_seq
 ALTER SEQUENCE public.invoices_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3852 (class 0 OID 0)
+-- TOC entry 3868 (class 0 OID 0)
 -- Dependencies: 227
 -- Name: invoices_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -938,7 +938,7 @@ CREATE SEQUENCE public.migrations_id_seq
 ALTER SEQUENCE public.migrations_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3853 (class 0 OID 0)
+-- TOC entry 3869 (class 0 OID 0)
 -- Dependencies: 269
 -- Name: migrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -984,7 +984,7 @@ CREATE SEQUENCE public.nocodb_config_id_seq
 ALTER SEQUENCE public.nocodb_config_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3854 (class 0 OID 0)
+-- TOC entry 3870 (class 0 OID 0)
 -- Dependencies: 238
 -- Name: nocodb_config_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -1032,7 +1032,7 @@ CREATE SEQUENCE public.orders_id_seq
 ALTER SEQUENCE public.orders_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3855 (class 0 OID 0)
+-- TOC entry 3871 (class 0 OID 0)
 -- Dependencies: 242
 -- Name: orders_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -1077,7 +1077,7 @@ CREATE SEQUENCE public.permissions_id_seq
 ALTER SEQUENCE public.permissions_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3856 (class 0 OID 0)
+-- TOC entry 3872 (class 0 OID 0)
 -- Dependencies: 254
 -- Name: permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -1124,7 +1124,7 @@ CREATE SEQUENCE public.publicities_id_seq
 ALTER SEQUENCE public.publicities_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3857 (class 0 OID 0)
+-- TOC entry 3873 (class 0 OID 0)
 -- Dependencies: 244
 -- Name: publicities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -1139,8 +1139,7 @@ ALTER SEQUENCE public.publicities_id_seq OWNED BY public.publicities.id;
 
 CREATE TABLE public.publicity_participations (
     publicity_id integer NOT NULL,
-    group_id integer NOT NULL,
-    created_at timestamp without time zone DEFAULT now()
+    group_id integer NOT NULL
 );
 
 
@@ -1183,7 +1182,7 @@ CREATE SEQUENCE public.reconciliation_comments_id_seq
 ALTER SEQUENCE public.reconciliation_comments_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3858 (class 0 OID 0)
+-- TOC entry 3874 (class 0 OID 0)
 -- Dependencies: 277
 -- Name: reconciliation_comments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -1242,7 +1241,7 @@ CREATE SEQUENCE public.roles_id_seq
 ALTER SEQUENCE public.roles_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3859 (class 0 OID 0)
+-- TOC entry 3875 (class 0 OID 0)
 -- Dependencies: 252
 -- Name: roles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -1292,7 +1291,7 @@ CREATE SEQUENCE public.sav_tickets_id_seq
 ALTER SEQUENCE public.sav_tickets_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3860 (class 0 OID 0)
+-- TOC entry 3876 (class 0 OID 0)
 -- Dependencies: 229
 -- Name: sav_tickets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -1364,7 +1363,7 @@ CREATE SEQUENCE public.stores_id_seq
 ALTER SEQUENCE public.stores_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3861 (class 0 OID 0)
+-- TOC entry 3877 (class 0 OID 0)
 -- Dependencies: 231
 -- Name: stores_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -1408,7 +1407,7 @@ CREATE SEQUENCE public.suppliers_id_seq
 ALTER SEQUENCE public.suppliers_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3862 (class 0 OID 0)
+-- TOC entry 3878 (class 0 OID 0)
 -- Dependencies: 240
 -- Name: suppliers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -1459,7 +1458,7 @@ CREATE SEQUENCE public.tasks_id_seq
 ALTER SEQUENCE public.tasks_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3863 (class 0 OID 0)
+-- TOC entry 3879 (class 0 OID 0)
 -- Dependencies: 250
 -- Name: tasks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -1521,6 +1520,51 @@ CREATE TABLE public.users (
 ALTER TABLE public.users OWNER TO neondb_owner;
 
 --
+-- TOC entry 280 (class 1259 OID 2383873)
+-- Name: weather_settings; Type: TABLE; Schema: public; Owner: neondb_owner
+--
+
+CREATE TABLE public.weather_settings (
+    id integer NOT NULL,
+    api_key character varying(255),
+    default_city character varying(255) DEFAULT 'Paris'::character varying NOT NULL,
+    units character varying(10) DEFAULT 'metric'::character varying NOT NULL,
+    update_interval integer DEFAULT 30 NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    location character varying(255) DEFAULT 'Paris'::character varying
+);
+
+
+ALTER TABLE public.weather_settings OWNER TO neondb_owner;
+
+--
+-- TOC entry 279 (class 1259 OID 2383872)
+-- Name: weather_settings_id_seq; Type: SEQUENCE; Schema: public; Owner: neondb_owner
+--
+
+CREATE SEQUENCE public.weather_settings_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.weather_settings_id_seq OWNER TO neondb_owner;
+
+--
+-- TOC entry 3880 (class 0 OID 0)
+-- Dependencies: 279
+-- Name: weather_settings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
+--
+
+ALTER SEQUENCE public.weather_settings_id_seq OWNED BY public.weather_settings.id;
+
+
+--
 -- TOC entry 274 (class 1259 OID 2359334)
 -- Name: webhook_bap_config; Type: TABLE; Schema: public; Owner: neondb_owner
 --
@@ -1539,7 +1583,7 @@ CREATE TABLE public.webhook_bap_config (
 ALTER TABLE public.webhook_bap_config OWNER TO neondb_owner;
 
 --
--- TOC entry 3864 (class 0 OID 0)
+-- TOC entry 3881 (class 0 OID 0)
 -- Dependencies: 274
 -- Name: TABLE webhook_bap_config; Type: COMMENT; Schema: public; Owner: neondb_owner
 --
@@ -1564,7 +1608,7 @@ CREATE SEQUENCE public.webhook_bap_config_id_seq
 ALTER SEQUENCE public.webhook_bap_config_id_seq OWNER TO neondb_owner;
 
 --
--- TOC entry 3865 (class 0 OID 0)
+-- TOC entry 3882 (class 0 OID 0)
 -- Dependencies: 273
 -- Name: webhook_bap_config_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: neondb_owner
 --
@@ -1573,7 +1617,7 @@ ALTER SEQUENCE public.webhook_bap_config_id_seq OWNED BY public.webhook_bap_conf
 
 
 --
--- TOC entry 3472 (class 2604 OID 2359310)
+-- TOC entry 3476 (class 2604 OID 2359310)
 -- Name: announcements id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1581,7 +1625,7 @@ ALTER TABLE ONLY public.announcements ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
--- TOC entry 3481 (class 2604 OID 2367492)
+-- TOC entry 3485 (class 2604 OID 2367492)
 -- Name: avoirs id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1589,7 +1633,7 @@ ALTER TABLE ONLY public.avoirs ALTER COLUMN id SET DEFAULT nextval('public.avoir
 
 
 --
--- TOC entry 3347 (class 2604 OID 24580)
+-- TOC entry 3352 (class 2604 OID 24580)
 -- Name: calendar_events id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1597,7 +1641,7 @@ ALTER TABLE ONLY public.calendar_events ALTER COLUMN id SET DEFAULT nextval('pub
 
 
 --
--- TOC entry 3352 (class 2604 OID 24593)
+-- TOC entry 3357 (class 2604 OID 24593)
 -- Name: client_orders id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1605,7 +1649,7 @@ ALTER TABLE ONLY public.client_orders ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
--- TOC entry 3357 (class 2604 OID 24608)
+-- TOC entry 3362 (class 2604 OID 24608)
 -- Name: command_items id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1613,7 +1657,7 @@ ALTER TABLE ONLY public.command_items ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
--- TOC entry 3358 (class 2604 OID 24617)
+-- TOC entry 3363 (class 2604 OID 24617)
 -- Name: commands id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1621,7 +1665,7 @@ ALTER TABLE ONLY public.commands ALTER COLUMN id SET DEFAULT nextval('public.com
 
 
 --
--- TOC entry 3411 (class 2604 OID 57529)
+-- TOC entry 3416 (class 2604 OID 57529)
 -- Name: customer_orders id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1629,7 +1673,7 @@ ALTER TABLE ONLY public.customer_orders ALTER COLUMN id SET DEFAULT nextval('pub
 
 
 --
--- TOC entry 3363 (class 2604 OID 24632)
+-- TOC entry 3368 (class 2604 OID 24632)
 -- Name: customers id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1637,7 +1681,7 @@ ALTER TABLE ONLY public.customers ALTER COLUMN id SET DEFAULT nextval('public.cu
 
 
 --
--- TOC entry 3467 (class 2604 OID 2342916)
+-- TOC entry 3471 (class 2604 OID 2342916)
 -- Name: dashboard_messages id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1645,7 +1689,7 @@ ALTER TABLE ONLY public.dashboard_messages ALTER COLUMN id SET DEFAULT nextval('
 
 
 --
--- TOC entry 3444 (class 2604 OID 73737)
+-- TOC entry 3448 (class 2604 OID 73737)
 -- Name: deliveries id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1653,7 +1697,7 @@ ALTER TABLE ONLY public.deliveries ALTER COLUMN id SET DEFAULT nextval('public.d
 
 
 --
--- TOC entry 3366 (class 2604 OID 24657)
+-- TOC entry 3371 (class 2604 OID 24657)
 -- Name: delivery_items id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1661,7 +1705,7 @@ ALTER TABLE ONLY public.delivery_items ALTER COLUMN id SET DEFAULT nextval('publ
 
 
 --
--- TOC entry 3419 (class 2604 OID 57545)
+-- TOC entry 3424 (class 2604 OID 57545)
 -- Name: dlc_products id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1669,7 +1713,7 @@ ALTER TABLE ONLY public.dlc_products ALTER COLUMN id SET DEFAULT nextval('public
 
 
 --
--- TOC entry 3386 (class 2604 OID 57454)
+-- TOC entry 3391 (class 2604 OID 57454)
 -- Name: groups id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1677,7 +1721,7 @@ ALTER TABLE ONLY public.groups ALTER COLUMN id SET DEFAULT nextval('public.group
 
 
 --
--- TOC entry 3460 (class 2604 OID 2310149)
+-- TOC entry 3464 (class 2604 OID 2310149)
 -- Name: invoice_verification_cache id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1685,7 +1729,7 @@ ALTER TABLE ONLY public.invoice_verification_cache ALTER COLUMN id SET DEFAULT n
 
 
 --
--- TOC entry 3456 (class 2604 OID 2285572)
+-- TOC entry 3460 (class 2604 OID 2285572)
 -- Name: invoice_verifications id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1693,7 +1737,7 @@ ALTER TABLE ONLY public.invoice_verifications ALTER COLUMN id SET DEFAULT nextva
 
 
 --
--- TOC entry 3368 (class 2604 OID 24680)
+-- TOC entry 3373 (class 2604 OID 24680)
 -- Name: invoices id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1701,7 +1745,7 @@ ALTER TABLE ONLY public.invoices ALTER COLUMN id SET DEFAULT nextval('public.inv
 
 
 --
--- TOC entry 3470 (class 2604 OID 2359300)
+-- TOC entry 3474 (class 2604 OID 2359300)
 -- Name: migrations id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1709,7 +1753,7 @@ ALTER TABLE ONLY public.migrations ALTER COLUMN id SET DEFAULT nextval('public.m
 
 
 --
--- TOC entry 3395 (class 2604 OID 57467)
+-- TOC entry 3400 (class 2604 OID 57467)
 -- Name: nocodb_config id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1717,7 +1761,7 @@ ALTER TABLE ONLY public.nocodb_config ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
--- TOC entry 3404 (class 2604 OID 57491)
+-- TOC entry 3409 (class 2604 OID 57491)
 -- Name: orders id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1725,7 +1769,7 @@ ALTER TABLE ONLY public.orders ALTER COLUMN id SET DEFAULT nextval('public.order
 
 
 --
--- TOC entry 3439 (class 2604 OID 57584)
+-- TOC entry 3444 (class 2604 OID 57584)
 -- Name: permissions id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1733,7 +1777,7 @@ ALTER TABLE ONLY public.permissions ALTER COLUMN id SET DEFAULT nextval('public.
 
 
 --
--- TOC entry 3408 (class 2604 OID 57516)
+-- TOC entry 3413 (class 2604 OID 57516)
 -- Name: publicities id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1741,7 +1785,7 @@ ALTER TABLE ONLY public.publicities ALTER COLUMN id SET DEFAULT nextval('public.
 
 
 --
--- TOC entry 3488 (class 2604 OID 2375684)
+-- TOC entry 3492 (class 2604 OID 2375684)
 -- Name: reconciliation_comments id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1749,7 +1793,7 @@ ALTER TABLE ONLY public.reconciliation_comments ALTER COLUMN id SET DEFAULT next
 
 
 --
--- TOC entry 3433 (class 2604 OID 57568)
+-- TOC entry 3438 (class 2604 OID 57568)
 -- Name: roles id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1757,7 +1801,7 @@ ALTER TABLE ONLY public.roles ALTER COLUMN id SET DEFAULT nextval('public.roles_
 
 
 --
--- TOC entry 3373 (class 2604 OID 24695)
+-- TOC entry 3378 (class 2604 OID 24695)
 -- Name: sav_tickets id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1765,7 +1809,7 @@ ALTER TABLE ONLY public.sav_tickets ALTER COLUMN id SET DEFAULT nextval('public.
 
 
 --
--- TOC entry 3378 (class 2604 OID 24710)
+-- TOC entry 3383 (class 2604 OID 24710)
 -- Name: stores id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1773,7 +1817,7 @@ ALTER TABLE ONLY public.stores ALTER COLUMN id SET DEFAULT nextval('public.store
 
 
 --
--- TOC entry 3399 (class 2604 OID 57479)
+-- TOC entry 3404 (class 2604 OID 57479)
 -- Name: suppliers id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1781,7 +1825,7 @@ ALTER TABLE ONLY public.suppliers ALTER COLUMN id SET DEFAULT nextval('public.su
 
 
 --
--- TOC entry 3428 (class 2604 OID 57555)
+-- TOC entry 3433 (class 2604 OID 57555)
 -- Name: tasks id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1789,7 +1833,15 @@ ALTER TABLE ONLY public.tasks ALTER COLUMN id SET DEFAULT nextval('public.tasks_
 
 
 --
--- TOC entry 3476 (class 2604 OID 2359337)
+-- TOC entry 3495 (class 2604 OID 2383876)
+-- Name: weather_settings id; Type: DEFAULT; Schema: public; Owner: neondb_owner
+--
+
+ALTER TABLE ONLY public.weather_settings ALTER COLUMN id SET DEFAULT nextval('public.weather_settings_id_seq'::regclass);
+
+
+--
+-- TOC entry 3480 (class 2604 OID 2359337)
 -- Name: webhook_bap_config id; Type: DEFAULT; Schema: public; Owner: neondb_owner
 --
 
@@ -1797,7 +1849,7 @@ ALTER TABLE ONLY public.webhook_bap_config ALTER COLUMN id SET DEFAULT nextval('
 
 
 --
--- TOC entry 3817 (class 0 OID 2359307)
+-- TOC entry 3831 (class 0 OID 2359307)
 -- Dependencies: 272
 -- Data for Name: announcements; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -1807,7 +1859,7 @@ COPY public.announcements (id, title, content, priority, author_id, group_id, cr
 
 
 --
--- TOC entry 3821 (class 0 OID 2367489)
+-- TOC entry 3835 (class 0 OID 2367489)
 -- Dependencies: 276
 -- Data for Name: avoirs; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -1817,7 +1869,7 @@ COPY public.avoirs (id, supplier_id, group_id, invoice_reference, amount, commen
 
 
 --
--- TOC entry 3761 (class 0 OID 24577)
+-- TOC entry 3775 (class 0 OID 24577)
 -- Dependencies: 216
 -- Data for Name: calendar_events; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -1833,7 +1885,7 @@ COPY public.calendar_events (id, title, description, user_id, store_id, start_da
 
 
 --
--- TOC entry 3763 (class 0 OID 24590)
+-- TOC entry 3777 (class 0 OID 24590)
 -- Dependencies: 218
 -- Data for Name: client_orders; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -1848,7 +1900,7 @@ COPY public.client_orders (id, order_number, customer_id, store_id, user_id, sta
 
 
 --
--- TOC entry 3765 (class 0 OID 24605)
+-- TOC entry 3779 (class 0 OID 24605)
 -- Dependencies: 220
 -- Data for Name: command_items; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -1872,7 +1924,7 @@ COPY public.command_items (id, command_id, product_name, product_code, quantity,
 
 
 --
--- TOC entry 3767 (class 0 OID 24614)
+-- TOC entry 3781 (class 0 OID 24614)
 -- Dependencies: 222
 -- Data for Name: commands; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -1887,7 +1939,7 @@ COPY public.commands (id, command_number, supplier_id, store_id, user_id, status
 
 
 --
--- TOC entry 3792 (class 0 OID 57526)
+-- TOC entry 3806 (class 0 OID 57526)
 -- Dependencies: 247
 -- Data for Name: customer_orders; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -1895,11 +1947,14 @@ COPY public.commands (id, command_number, supplier_id, store_id, user_id, status
 COPY public.customer_orders (id, order_taker, customer_name, customer_phone, customer_email, product_designation, product_reference, gencode, quantity, supplier_id, status, deposit, is_promotional_price, customer_notified, notes, group_id, created_by, created_at, updated_at) FROM stdin;
 1	moi	schal	0623154654	\N	qsdfg	erf13213	3660092323745	1	1	En attente de Commande	10.00	f	f	\N	3	1	2025-07-19 19:03:44.739	2025-07-19 19:03:44.739
 2	moi	schal	0623154654	\N	fgdsh	erf13213	366092323745	1	1	En attente de Commande	0.00	f	f	\N	5	_1753182518439	2025-07-22 13:19:27.447	2025-07-22 13:19:27.447
+336583	admin	Test Client 336583	0123456789	\N	Test Product Designation	\N	GENCODE336583	1	1	pending	0.00	f	f	\N	1	admin	2025-09-11 10:57:11.071226	2025-09-11 10:57:11.071226
+685430	admin	Test Client 685430	0123456789	\N	Test Product Designation	\N	GENCODE685430	1	1	pending	0.00	f	f	\N	1	admin	2025-09-11 10:57:46.938934	2025-09-11 10:57:46.938934
+409686	admin	Test Client 409686	0123456789	\N	Test Product Designation	\N	GENCODE409686	1	1	pending	0.00	f	f	\N	1	admin	2025-09-11 10:58:00.328537	2025-09-11 10:58:00.328537
 \.
 
 
 --
--- TOC entry 3769 (class 0 OID 24629)
+-- TOC entry 3783 (class 0 OID 24629)
 -- Dependencies: 224
 -- Data for Name: customers; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -1917,7 +1972,7 @@ COPY public.customers (id, first_name, last_name, email, phone, address, store_i
 
 
 --
--- TOC entry 3813 (class 0 OID 2342913)
+-- TOC entry 3827 (class 0 OID 2342913)
 -- Dependencies: 268
 -- Data for Name: dashboard_messages; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -1927,28 +1982,28 @@ COPY public.dashboard_messages (id, title, content, type, store_id, created_by, 
 
 
 --
--- TOC entry 3807 (class 0 OID 819214)
+-- TOC entry 3821 (class 0 OID 819214)
 -- Dependencies: 262
 -- Data for Name: database_backups; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
 
 COPY public.database_backups (id, filename, description, size, created_at, created_by, tables_count, status, backup_type) FROM stdin;
-bAQDAmP7qC6yF_v4hEqAp	backup_automatic_2025-09-01T02-00-00-001Z.sql	Automatique backup du 01/09/2025	104544	2025-09-01 02:00:00.492317	system	31	completed	automatic
-_nmeY9-4XKisNTkPDKvmM	backup_automatic_2025-09-02T02-46-17-030Z.sql	Automatique backup du 02/09/2025	104709	2025-09-02 02:46:17.044913	system	31	completed	automatic
-ua9Z_UKJ8qDpu78wslJbI	backup_automatic_2025-09-03T08-16-31-540Z.sql	Automatique backup du 03/09/2025	104873	2025-09-03 08:16:31.55345	system	31	completed	automatic
-f-mPzyfJ0jAh3N3cCyKGm	backup_automatic_2025-09-04T07-09-57-386Z.sql	Automatique backup du 04/09/2025	114696	2025-09-04 07:09:57.42171	system	34	completed	automatic
-Eyf_R0g6S9fWiyctBmcFv	backup_automatic_2025-09-05T05-12-40-865Z.sql	Automatique backup du 05/09/2025	114861	2025-09-05 05:12:40.898026	system	34	completed	automatic
-uhFPspueUqUrvb6ZUZEIH	backup_automatic_2025-09-06T07-22-50-169Z.sql	Automatique backup du 06/09/2025	115026	2025-09-06 07:22:50.200602	system	34	completed	automatic
-vSz_RhYfKOiZZ9iOa--i3	backup_automatic_2025-09-07T06-43-47-902Z.sql	Automatique backup du 07/09/2025	115191	2025-09-07 06:43:47.933813	system	34	completed	automatic
-dO8X9cwfjAYIo3Vf5xhN5	backup_automatic_2025-09-08T08-16-07-330Z.sql	Automatique backup du 08/09/2025	115196	2025-09-08 08:16:07.366382	system	34	completed	automatic
-lMiIY4CyjQz3je-1ZkmPp	backup_automatic_2025-09-09T05-44-46-213Z.sql	Automatique backup du 09/09/2025	117617	2025-09-09 05:44:46.240552	system	35	completed	automatic
--ExxMCChA_LAMKmXOLbw2	backup_automatic_2025-09-10T05-59-02-237Z.sql	Automatique backup du 10/09/2025	117601	2025-09-10 05:59:02.267425	system	35	completed	automatic
-V8T82lGYiVOyqw2-PwZsZ	backup_automatic_2025-09-11T05-59-54-844Z.sql	Automatique backup du 11/09/2025	0	2025-09-11 05:59:54.880714	system	0	creating	automatic
+V8T82lGYiVOyqw2-PwZsZ	backup_automatic_2025-09-11T05-59-54-844Z.sql	Automatique backup du 11/09/2025	121198	2025-09-11 05:59:54.880714	system	36	completed	automatic
+AVRKx6fkmqgASTdspwUkz	backup_automatic_2025-09-12T10-06-11-906Z.sql	Automatique backup du 12/09/2025	129519	2025-09-12 10:06:11.934102	system	36	completed	automatic
+tW8PypCgNiWzbeNlmffB5	backup_automatic_2025-09-13T08-56-08-317Z.sql	Automatique backup du 13/09/2025	129519	2025-09-13 08:56:08.313083	system	36	completed	automatic
+o-SjCztDrO6s4euLXW89b	backup_automatic_2025-09-14T06-47-09-384Z.sql	Automatique backup du 14/09/2025	129520	2025-09-14 06:47:09.423331	system	36	completed	automatic
+6kVpBxcqhbDpUojzGo4Is	backup_automatic_2025-09-15T06-06-14-991Z.sql	Automatique backup du 15/09/2025	129521	2025-09-15 06:06:15.021982	system	36	completed	automatic
+3BXbMdVkhtSryOk3HRGkp	backup_automatic_2025-09-17T21-56-37-345Z.sql	Automatique backup du 17/09/2025	131556	2025-09-17 21:56:37.375543	system	37	completed	automatic
+FBwVzTaCwB4AS6GVU6SJ9	backup_automatic_2025-09-19T06-11-49-625Z.sql	Automatique backup du 19/09/2025	131556	2025-09-19 06:11:49.678533	system	37	completed	automatic
+cICxm578x1hf1vPaQJROL	backup_automatic_2025-09-20T02-02-55-254Z.sql	Automatique backup du 20/09/2025	131556	2025-09-20 02:02:55.280114	system	37	completed	automatic
+MDAobkh74ZgZZI9oS2XCI	backup_automatic_2025-09-21T06-22-14-480Z.sql	Automatique backup du 21/09/2025	131555	2025-09-21 06:22:14.50849	system	37	completed	automatic
+V__NOBc-Hg8Kr9yiiGqna	backup_automatic_2025-09-22T05-28-11-122Z.sql	Automatique backup du 22/09/2025	131553	2025-09-22 05:28:11.1653	system	37	completed	automatic
+NJ_zevppkB1fhTqNVpHVQ	backup_automatic_2025-09-23T08-42-36-690Z.sql	Automatique backup du 23/09/2025	0	2025-09-23 08:42:36.721996	system	0	creating	automatic
 \.
 
 
 --
--- TOC entry 3804 (class 0 OID 73734)
+-- TOC entry 3818 (class 0 OID 73734)
 -- Dependencies: 259
 -- Data for Name: deliveries; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -1992,7 +2047,7 @@ COPY public.deliveries (id, order_id, supplier_id, group_id, scheduled_date, del
 
 
 --
--- TOC entry 3771 (class 0 OID 24654)
+-- TOC entry 3785 (class 0 OID 24654)
 -- Dependencies: 226
 -- Data for Name: delivery_items; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2002,7 +2057,7 @@ COPY public.delivery_items (id, delivery_id, command_item_id, product_name, quan
 
 
 --
--- TOC entry 3794 (class 0 OID 57542)
+-- TOC entry 3808 (class 0 OID 57542)
 -- Dependencies: 249
 -- Data for Name: dlc_products; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2013,11 +2068,12 @@ COPY public.dlc_products (id, name, gencode, dlc_date, quantity, store_id, creat
 4	Produit Expiré	3456789012345	2025-07-15	1	\N	2025-07-19 22:35:49.651214	4	admin_local	en_cours	\N	2025-07-15	3456789012345	\N	1	Produit Expiré	DLC	unité	Magasin	15	Déjà expiré	2025-07-19 22:35:49.651214	\N	f	\N	\N
 7	Produit Validé Test	VAL123	2025-08-15	1	\N	2025-07-19 23:54:00.380592	4	admin	valides	\N	\N	\N	\N	1	Produit Validé Test	DLC	unité	Magasin	15	Produit avec statut validé	2025-07-19 23:54:00.380592	\N	f	\N	\N
 15	coca 	366092323745	\N	1	\N	2025-07-22 13:35:02.427	5	_1753182518439	en_cours	\N	2025-07-27	\N	\N	3	coca 	dlc	unité	Magasin	15		2025-07-22 13:35:02.427	\N	f	\N	\N
+17	DLC Produit Test	zFGwX	\N	\N	\N	2025-09-11 11:11:28.243179	\N	\N	valides	\N	2026-01-01	\N	\N	\N	DLC Produit Test	DLC	unité	Magasin	15	\N	2025-09-11 11:11:28.243179	\N	f	\N	\N
 \.
 
 
 --
--- TOC entry 3782 (class 0 OID 57451)
+-- TOC entry 3796 (class 0 OID 57451)
 -- Dependencies: 237
 -- Data for Name: groups; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2030,7 +2086,7 @@ COPY public.groups (id, name, color, address, phone, email, nocodb_config_id, no
 
 
 --
--- TOC entry 3811 (class 0 OID 2310146)
+-- TOC entry 3825 (class 0 OID 2310146)
 -- Dependencies: 266
 -- Data for Name: invoice_verification_cache; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2040,7 +2096,7 @@ COPY public.invoice_verification_cache (id, cache_key, group_id, invoice_referen
 
 
 --
--- TOC entry 3809 (class 0 OID 2285569)
+-- TOC entry 3823 (class 0 OID 2285569)
 -- Dependencies: 264
 -- Data for Name: invoice_verifications; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2055,7 +2111,7 @@ COPY public.invoice_verifications (id, delivery_id, group_id, invoice_reference,
 
 
 --
--- TOC entry 3773 (class 0 OID 24677)
+-- TOC entry 3787 (class 0 OID 24677)
 -- Dependencies: 228
 -- Data for Name: invoices; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2065,7 +2121,7 @@ COPY public.invoices (id, invoice_number, command_id, delivery_id, store_id, use
 
 
 --
--- TOC entry 3815 (class 0 OID 2359297)
+-- TOC entry 3829 (class 0 OID 2359297)
 -- Dependencies: 270
 -- Data for Name: migrations; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2080,7 +2136,7 @@ COPY public.migrations (id, filename, executed_at) FROM stdin;
 
 
 --
--- TOC entry 3784 (class 0 OID 57464)
+-- TOC entry 3798 (class 0 OID 57464)
 -- Dependencies: 239
 -- Data for Name: nocodb_config; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2091,7 +2147,7 @@ COPY public.nocodb_config (id, name, base_url, project_id, api_token, descriptio
 
 
 --
--- TOC entry 3788 (class 0 OID 57488)
+-- TOC entry 3802 (class 0 OID 57488)
 -- Dependencies: 243
 -- Data for Name: orders; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2110,7 +2166,7 @@ COPY public.orders (id, supplier_id, group_id, planned_date, quantity, unit, sta
 
 
 --
--- TOC entry 3800 (class 0 OID 57581)
+-- TOC entry 3814 (class 0 OID 57581)
 -- Dependencies: 255
 -- Data for Name: permissions; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2174,7 +2230,7 @@ COPY public.permissions (id, name, display_name, description, category, action, 
 
 
 --
--- TOC entry 3790 (class 0 OID 57513)
+-- TOC entry 3804 (class 0 OID 57513)
 -- Dependencies: 245
 -- Data for Name: publicities; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2184,7 +2240,6 @@ COPY public.publicities (id, pub_number, designation, title, description, start_
 4	TEST-FORCE-PROD	Test Force Production	\N	\N	2025-07-23	2025-07-29	2025	1	2025-07-19 22:39:13.937601	2025-07-19 22:39:13.937601
 5	TEST-ERROR	Test Error	\N	\N	2025-07-24	2025-07-30	2025	1	2025-07-19 22:54:05.573607	2025-07-19 22:54:05.573607
 6	2501	wxcvwxc	\N	\N	2025-07-01	2025-07-06	2025	1	2025-07-19 22:55:06.907432	2025-07-19 22:55:06.907432
-7	DEBUG-PROD	Debug Production	\N	\N	2025-07-25	2025-07-31	2025	1	2025-07-19 22:56:05.296286	2025-07-19 22:56:05.296286
 9	FINAL-TEST	Test Final Production	\N	\N	2025-07-27	2025-08-02	2025	1	2025-07-19 23:03:21.499342	2025-07-19 23:03:21.499342
 8	DIAG-PROD	Diagnostic Production	\N	\N	2025-07-26	2025-08-01	2025	1	2025-07-19 22:58:31.680917	2025-07-20 09:09:26.486
 2	TEST123	Test	\N	\N	2025-07-20	2025-07-25	2025	1	2025-07-19 22:38:10.039397	2025-07-20 09:13:42.375
@@ -2193,27 +2248,26 @@ COPY public.publicities (id, pub_number, designation, title, description, start_
 
 
 --
--- TOC entry 3802 (class 0 OID 57615)
+-- TOC entry 3816 (class 0 OID 57615)
 -- Dependencies: 257
 -- Data for Name: publicity_participations; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
 
-COPY public.publicity_participations (publicity_id, group_id, created_at) FROM stdin;
-1	5	2025-07-19 21:38:15.036215
-3	4	2025-07-19 22:38:52.193439
-4	4	2025-07-19 22:39:13.987098
-5	4	2025-07-19 22:54:05.624748
-6	5	2025-07-19 22:55:06.955089
-7	4	2025-07-19 22:56:05.344704
-9	5	2025-07-19 23:03:21.551156
-2	4	2025-07-20 09:13:42.436078
-2	5	2025-07-20 09:13:42.436078
-10	5	2025-07-22 15:37:06.737248
+COPY public.publicity_participations (publicity_id, group_id) FROM stdin;
+1	5
+3	4
+4	4
+5	4
+6	5
+9	5
+2	4
+2	5
+10	5
 \.
 
 
 --
--- TOC entry 3823 (class 0 OID 2375681)
+-- TOC entry 3837 (class 0 OID 2375681)
 -- Dependencies: 278
 -- Data for Name: reconciliation_comments; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2223,7 +2277,7 @@ COPY public.reconciliation_comments (id, content, type, delivery_id, author_id, 
 
 
 --
--- TOC entry 3801 (class 0 OID 57609)
+-- TOC entry 3815 (class 0 OID 57609)
 -- Dependencies: 256
 -- Data for Name: role_permissions; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2401,7 +2455,7 @@ COPY public.role_permissions (role_id, permission_id, created_at) FROM stdin;
 
 
 --
--- TOC entry 3798 (class 0 OID 57565)
+-- TOC entry 3812 (class 0 OID 57565)
 -- Dependencies: 253
 -- Data for Name: roles; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2415,7 +2469,7 @@ COPY public.roles (id, name, display_name, description, color, is_system, is_act
 
 
 --
--- TOC entry 3775 (class 0 OID 24692)
+-- TOC entry 3789 (class 0 OID 24692)
 -- Dependencies: 230
 -- Data for Name: sav_tickets; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2430,7 +2484,7 @@ COPY public.sav_tickets (id, ticket_number, customer_id, store_id, user_id, assi
 
 
 --
--- TOC entry 3778 (class 0 OID 32770)
+-- TOC entry 3792 (class 0 OID 32770)
 -- Dependencies: 233
 -- Data for Name: session; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2441,7 +2495,7 @@ COPY public.session (sid, sess, expire) FROM stdin;
 
 
 --
--- TOC entry 3779 (class 0 OID 57427)
+-- TOC entry 3793 (class 0 OID 57427)
 -- Dependencies: 234
 -- Data for Name: sessions; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2451,7 +2505,7 @@ COPY public.sessions (sid, sess, expire) FROM stdin;
 
 
 --
--- TOC entry 3777 (class 0 OID 24707)
+-- TOC entry 3791 (class 0 OID 24707)
 -- Dependencies: 232
 -- Data for Name: stores; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2466,7 +2520,7 @@ COPY public.stores (id, name, address, phone, email, is_active, created_at, upda
 
 
 --
--- TOC entry 3786 (class 0 OID 57476)
+-- TOC entry 3800 (class 0 OID 57476)
 -- Dependencies: 241
 -- Data for Name: suppliers; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2481,7 +2535,7 @@ COPY public.suppliers (id, name, contact, phone, has_dlc, created_at, updated_at
 
 
 --
--- TOC entry 3796 (class 0 OID 57552)
+-- TOC entry 3810 (class 0 OID 57552)
 -- Dependencies: 251
 -- Data for Name: tasks; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2500,11 +2554,81 @@ COPY public.tasks (id, title, description, assigned_to, due_date, priority, stat
 24	sdqf	qsdf	qsdf	\N	medium	pending	\N	2025-07-23 11:59:35.323732	2025-07-23 11:59:35.323732	1	4	2025-07-25 00:00:00	\N	\N
 25	aezrhgsq	qsdf	azerze	2025-07-24	medium	pending	\N	2025-07-23 12:00:20.040255	2025-07-23 12:00:29.95404	1	4	2025-07-23 00:00:00	\N	\N
 26	erfggf	qsdf	qsdf	2025-07-31	medium	pending	\N	2025-07-23 12:03:22.50558	2025-07-23 12:03:22.50558	1	4	2025-07-27 00:00:00	\N	\N
+27	DB Task 0		\N	\N	medium	pending	\N	2025-09-11 09:49:27.040745	2025-09-11 09:49:27.040745	admin	1	\N	\N	\N
+28	DB Task 1		\N	\N	medium	pending	\N	2025-09-11 09:49:27.040745	2025-09-11 09:49:27.040745	admin	1	\N	\N	\N
+29	DB Task 2		\N	\N	medium	pending	\N	2025-09-11 09:49:27.040745	2025-09-11 09:49:27.040745	admin	1	\N	\N	\N
+30	DB Task 3		\N	\N	medium	pending	\N	2025-09-11 09:49:27.040745	2025-09-11 09:49:27.040745	admin	1	\N	\N	\N
+31	DB Task 4		\N	\N	medium	pending	\N	2025-09-11 09:49:27.040745	2025-09-11 09:49:27.040745	admin	1	\N	\N	\N
+32	DB Task 5		\N	\N	medium	pending	\N	2025-09-11 09:49:27.040745	2025-09-11 09:49:27.040745	admin	1	\N	\N	\N
+33	DB Task 6		\N	\N	medium	pending	\N	2025-09-11 09:49:27.040745	2025-09-11 09:49:27.040745	admin	1	\N	\N	\N
+34	DB Task 7		\N	\N	medium	pending	\N	2025-09-11 09:49:27.040745	2025-09-11 09:49:27.040745	admin	1	\N	\N	\N
+35	DB Task 8		\N	\N	medium	pending	\N	2025-09-11 09:49:27.040745	2025-09-11 09:49:27.040745	admin	1	\N	\N	\N
+36	DB Task 9		\N	\N	medium	pending	\N	2025-09-11 09:49:27.040745	2025-09-11 09:49:27.040745	admin	1	\N	\N	\N
+37	DB Task 0		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+38	DB Task 1		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+39	DB Task 2		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+40	DB Task 3		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+41	DB Task 4		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+42	DB Task 5		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+43	DB Task 6		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+44	DB Task 7		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+45	DB Task 8		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+46	DB Task 9		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+47	DB Task 10		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+48	DB Task 11		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+49	DB Task 12		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+50	DB Task 13		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+51	DB Task 14		\N	\N	medium	pending	\N	2025-09-11 09:50:18.16913	2025-09-11 09:50:18.16913	admin	1	\N	\N	\N
+52	DB Task 0		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+53	DB Task 1		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+54	DB Task 2		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+55	DB Task 3		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+56	DB Task 4		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+57	DB Task 5		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+58	DB Task 6		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+59	DB Task 7		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+60	DB Task 8		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+61	DB Task 9		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+62	DB Task 10		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+63	DB Task 11		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+64	DB Task 12		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+65	DB Task 13		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+66	DB Task 14		\N	\N	medium	pending	\N	2025-09-11 09:52:12.380896	2025-09-11 09:52:12.380896	admin	1	\N	\N	\N
+67	DB Task 0		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+68	DB Task 1		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+69	DB Task 2		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+70	DB Task 3		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+71	DB Task 4		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+72	DB Task 5		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+73	DB Task 6		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+74	DB Task 7		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+75	DB Task 8		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+76	DB Task 9		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+77	DB Task 10		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+78	DB Task 11		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+79	DB Task 12		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+80	DB Task 13		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+81	DB Task 14		\N	\N	medium	pending	\N	2025-09-11 09:53:15.657202	2025-09-11 09:53:15.657202	admin	1	\N	\N	\N
+82	DB Task 0		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+83	DB Task 1		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+84	DB Task 2		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+85	DB Task 3		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+86	DB Task 4		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+87	DB Task 5		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+88	DB Task 6		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+89	DB Task 7		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+90	DB Task 8		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+91	DB Task 9		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+92	DB Task 10		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+93	DB Task 11		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+94	DB Task 12		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+95	DB Task 13		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
+96	DB Task 14		\N	\N	medium	pending	\N	2025-09-11 10:00:06.295601	2025-09-11 10:00:06.295601	admin	1	\N	\N	\N
 \.
 
 
 --
--- TOC entry 3806 (class 0 OID 720923)
+-- TOC entry 3820 (class 0 OID 720923)
 -- Dependencies: 261
 -- Data for Name: user_groups; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2520,7 +2644,7 @@ _1753185587842	1	\N	2025-07-22 11:59:52.30638
 
 
 --
--- TOC entry 3805 (class 0 OID 720910)
+-- TOC entry 3819 (class 0 OID 720910)
 -- Dependencies: 260
 -- Data for Name: user_roles; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2530,7 +2654,7 @@ COPY public.user_roles (user_id, role_id, assigned_by, assigned_at) FROM stdin;
 
 
 --
--- TOC entry 3780 (class 0 OID 57435)
+-- TOC entry 3794 (class 0 OID 57435)
 -- Dependencies: 235
 -- Data for Name: users; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2542,12 +2666,23 @@ manager_demo	manager	manager@logiflow.fr	Jean Manager	Jean	Manager	\N	$2b$10$K1B
 ff292_employee	ff292	ff292@logiflow.com	Employee Frouard	Employee	Frouard	\N	$2b$10$K1BL9HqNqFp2/Xb1QgXzDe8XQBOKcNKJ8vDbKcBbCJpWlGsQp3X3W	employee	t	2025-07-22 09:18:48.919512	2025-07-22 09:30:26.116
 _1753182518439	Nicolas	nicolas@logiflow.fr	Nicolas Directeur	Nicolas	Directeur	\N	$2b$10$K1BL9HqNqFp2/Xb1QgXzDe8XQBOKcNKJ8vDbKcBbCJpWlGsQp3X3W	directeur	t	2025-07-22 11:49:44.596384	2025-07-22 12:07:05.346
 directeur_demo	directeur	directeur@logiflow.fr	Pierre Directeur	Pierre	Directeur	\N	710984331d05d1edeede5de8117f72ee74dcf0450a97ec5f945323a65268849807d0d4e4256192ac8da3f101fb1f54fd7780c91639d946ac1ff4071c0b6592ab.138cf15d1b1d88f6148f180864cb2f51	directeur	t	2025-07-22 10:38:26.043656	2025-07-22 12:06:07.324
-1	admin	admin@logiflow.com	Admin System	Michael	SCHAL	\N	e31f77538c9ba3b4f02c74d2599c01c30b20daa1bacd28f66f256a37537542a5872b87219b38f39ec73793edf8caa8bb9c0d0815635f0332b47cf2edc6a389a3.36b85d2975a50844c490936e0afb3ef8	admin	f	2025-07-19 18:54:37.64216	2025-08-17 16:02:53.559
+admin_local	admin	admin@logiflow.com	\N	Administrateur	Système	\N	724b51c8c2cfe888c9881bd7b70eb6467c6f719ac0ef698493718095c21db94ac737773e1fd830ead26bcb12e33f613d08feefc7dd7e5f7b82e5d74f51f0e057.c139b9fafa8a156f5049a06b53c4e4ee	admin	f	2025-09-22 14:57:03.467386	2025-09-22 14:57:03.467386
 \.
 
 
 --
--- TOC entry 3819 (class 0 OID 2359334)
+-- TOC entry 3839 (class 0 OID 2383873)
+-- Dependencies: 280
+-- Data for Name: weather_settings; Type: TABLE DATA; Schema: public; Owner: neondb_owner
+--
+
+COPY public.weather_settings (id, api_key, default_city, units, update_interval, is_active, created_at, updated_at, location) FROM stdin;
+1	6PSHYLBJB9EEYNZ7NDQ5BPGBZ	Paris	metric	30	t	2025-09-15 08:40:40.083931	2025-09-15 08:40:40.083931	Nancy, France
+\.
+
+
+--
+-- TOC entry 3833 (class 0 OID 2359334)
 -- Dependencies: 274
 -- Data for Name: webhook_bap_config; Type: TABLE DATA; Schema: public; Owner: neondb_owner
 --
@@ -2558,7 +2693,7 @@ COPY public.webhook_bap_config (id, name, webhook_url, description, is_active, c
 
 
 --
--- TOC entry 3866 (class 0 OID 0)
+-- TOC entry 3883 (class 0 OID 0)
 -- Dependencies: 271
 -- Name: announcements_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2567,7 +2702,7 @@ SELECT pg_catalog.setval('public.announcements_id_seq', 1, false);
 
 
 --
--- TOC entry 3867 (class 0 OID 0)
+-- TOC entry 3884 (class 0 OID 0)
 -- Dependencies: 275
 -- Name: avoirs_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2576,7 +2711,7 @@ SELECT pg_catalog.setval('public.avoirs_id_seq', 1, false);
 
 
 --
--- TOC entry 3868 (class 0 OID 0)
+-- TOC entry 3885 (class 0 OID 0)
 -- Dependencies: 215
 -- Name: calendar_events_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2585,7 +2720,7 @@ SELECT pg_catalog.setval('public.calendar_events_id_seq', 6, true);
 
 
 --
--- TOC entry 3869 (class 0 OID 0)
+-- TOC entry 3886 (class 0 OID 0)
 -- Dependencies: 217
 -- Name: client_orders_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2594,7 +2729,7 @@ SELECT pg_catalog.setval('public.client_orders_id_seq', 5, true);
 
 
 --
--- TOC entry 3870 (class 0 OID 0)
+-- TOC entry 3887 (class 0 OID 0)
 -- Dependencies: 219
 -- Name: command_items_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2603,7 +2738,7 @@ SELECT pg_catalog.setval('public.command_items_id_seq', 14, true);
 
 
 --
--- TOC entry 3871 (class 0 OID 0)
+-- TOC entry 3888 (class 0 OID 0)
 -- Dependencies: 221
 -- Name: commands_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2612,7 +2747,7 @@ SELECT pg_catalog.setval('public.commands_id_seq', 8, true);
 
 
 --
--- TOC entry 3872 (class 0 OID 0)
+-- TOC entry 3889 (class 0 OID 0)
 -- Dependencies: 246
 -- Name: customer_orders_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2621,7 +2756,7 @@ SELECT pg_catalog.setval('public.customer_orders_id_seq', 2, true);
 
 
 --
--- TOC entry 3873 (class 0 OID 0)
+-- TOC entry 3890 (class 0 OID 0)
 -- Dependencies: 223
 -- Name: customers_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2630,7 +2765,7 @@ SELECT pg_catalog.setval('public.customers_id_seq', 8, true);
 
 
 --
--- TOC entry 3874 (class 0 OID 0)
+-- TOC entry 3891 (class 0 OID 0)
 -- Dependencies: 267
 -- Name: dashboard_messages_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2639,7 +2774,7 @@ SELECT pg_catalog.setval('public.dashboard_messages_id_seq', 2, true);
 
 
 --
--- TOC entry 3875 (class 0 OID 0)
+-- TOC entry 3892 (class 0 OID 0)
 -- Dependencies: 258
 -- Name: deliveries_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2648,7 +2783,7 @@ SELECT pg_catalog.setval('public.deliveries_id_seq', 133, true);
 
 
 --
--- TOC entry 3876 (class 0 OID 0)
+-- TOC entry 3893 (class 0 OID 0)
 -- Dependencies: 225
 -- Name: delivery_items_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2657,16 +2792,16 @@ SELECT pg_catalog.setval('public.delivery_items_id_seq', 1, false);
 
 
 --
--- TOC entry 3877 (class 0 OID 0)
+-- TOC entry 3894 (class 0 OID 0)
 -- Dependencies: 248
 -- Name: dlc_products_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
 
-SELECT pg_catalog.setval('public.dlc_products_id_seq', 15, true);
+SELECT pg_catalog.setval('public.dlc_products_id_seq', 17, true);
 
 
 --
--- TOC entry 3878 (class 0 OID 0)
+-- TOC entry 3895 (class 0 OID 0)
 -- Dependencies: 236
 -- Name: groups_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2675,7 +2810,7 @@ SELECT pg_catalog.setval('public.groups_id_seq', 5, true);
 
 
 --
--- TOC entry 3879 (class 0 OID 0)
+-- TOC entry 3896 (class 0 OID 0)
 -- Dependencies: 265
 -- Name: invoice_verification_cache_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2684,7 +2819,7 @@ SELECT pg_catalog.setval('public.invoice_verification_cache_id_seq', 1, false);
 
 
 --
--- TOC entry 3880 (class 0 OID 0)
+-- TOC entry 3897 (class 0 OID 0)
 -- Dependencies: 263
 -- Name: invoice_verifications_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2693,7 +2828,7 @@ SELECT pg_catalog.setval('public.invoice_verifications_id_seq', 15, true);
 
 
 --
--- TOC entry 3881 (class 0 OID 0)
+-- TOC entry 3898 (class 0 OID 0)
 -- Dependencies: 227
 -- Name: invoices_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2702,7 +2837,7 @@ SELECT pg_catalog.setval('public.invoices_id_seq', 1, false);
 
 
 --
--- TOC entry 3882 (class 0 OID 0)
+-- TOC entry 3899 (class 0 OID 0)
 -- Dependencies: 269
 -- Name: migrations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2711,7 +2846,7 @@ SELECT pg_catalog.setval('public.migrations_id_seq', 5, true);
 
 
 --
--- TOC entry 3883 (class 0 OID 0)
+-- TOC entry 3900 (class 0 OID 0)
 -- Dependencies: 238
 -- Name: nocodb_config_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2720,7 +2855,7 @@ SELECT pg_catalog.setval('public.nocodb_config_id_seq', 1, true);
 
 
 --
--- TOC entry 3884 (class 0 OID 0)
+-- TOC entry 3901 (class 0 OID 0)
 -- Dependencies: 242
 -- Name: orders_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2729,7 +2864,7 @@ SELECT pg_catalog.setval('public.orders_id_seq', 9, true);
 
 
 --
--- TOC entry 3885 (class 0 OID 0)
+-- TOC entry 3902 (class 0 OID 0)
 -- Dependencies: 254
 -- Name: permissions_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2738,7 +2873,7 @@ SELECT pg_catalog.setval('public.permissions_id_seq', 108, true);
 
 
 --
--- TOC entry 3886 (class 0 OID 0)
+-- TOC entry 3903 (class 0 OID 0)
 -- Dependencies: 244
 -- Name: publicities_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2747,7 +2882,7 @@ SELECT pg_catalog.setval('public.publicities_id_seq', 10, true);
 
 
 --
--- TOC entry 3887 (class 0 OID 0)
+-- TOC entry 3904 (class 0 OID 0)
 -- Dependencies: 277
 -- Name: reconciliation_comments_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2756,7 +2891,7 @@ SELECT pg_catalog.setval('public.reconciliation_comments_id_seq', 1, false);
 
 
 --
--- TOC entry 3888 (class 0 OID 0)
+-- TOC entry 3905 (class 0 OID 0)
 -- Dependencies: 252
 -- Name: roles_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2765,7 +2900,7 @@ SELECT pg_catalog.setval('public.roles_id_seq', 11, true);
 
 
 --
--- TOC entry 3889 (class 0 OID 0)
+-- TOC entry 3906 (class 0 OID 0)
 -- Dependencies: 229
 -- Name: sav_tickets_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2774,7 +2909,7 @@ SELECT pg_catalog.setval('public.sav_tickets_id_seq', 8, true);
 
 
 --
--- TOC entry 3890 (class 0 OID 0)
+-- TOC entry 3907 (class 0 OID 0)
 -- Dependencies: 231
 -- Name: stores_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2783,7 +2918,7 @@ SELECT pg_catalog.setval('public.stores_id_seq', 5, true);
 
 
 --
--- TOC entry 3891 (class 0 OID 0)
+-- TOC entry 3908 (class 0 OID 0)
 -- Dependencies: 240
 -- Name: suppliers_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2792,16 +2927,25 @@ SELECT pg_catalog.setval('public.suppliers_id_seq', 5, true);
 
 
 --
--- TOC entry 3892 (class 0 OID 0)
+-- TOC entry 3909 (class 0 OID 0)
 -- Dependencies: 250
 -- Name: tasks_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
 
-SELECT pg_catalog.setval('public.tasks_id_seq', 26, true);
+SELECT pg_catalog.setval('public.tasks_id_seq', 96, true);
 
 
 --
--- TOC entry 3893 (class 0 OID 0)
+-- TOC entry 3910 (class 0 OID 0)
+-- Dependencies: 279
+-- Name: weather_settings_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
+--
+
+SELECT pg_catalog.setval('public.weather_settings_id_seq', 1, true);
+
+
+--
+-- TOC entry 3911 (class 0 OID 0)
 -- Dependencies: 273
 -- Name: webhook_bap_config_id_seq; Type: SEQUENCE SET; Schema: public; Owner: neondb_owner
 --
@@ -2810,7 +2954,7 @@ SELECT pg_catalog.setval('public.webhook_bap_config_id_seq', 1, true);
 
 
 --
--- TOC entry 3596 (class 2606 OID 2359318)
+-- TOC entry 3608 (class 2606 OID 2359318)
 -- Name: announcements announcements_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2819,7 +2963,7 @@ ALTER TABLE ONLY public.announcements
 
 
 --
--- TOC entry 3604 (class 2606 OID 2367502)
+-- TOC entry 3616 (class 2606 OID 2367502)
 -- Name: avoirs avoirs_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2828,7 +2972,7 @@ ALTER TABLE ONLY public.avoirs
 
 
 --
--- TOC entry 3496 (class 2606 OID 24588)
+-- TOC entry 3508 (class 2606 OID 24588)
 -- Name: calendar_events calendar_events_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2837,7 +2981,7 @@ ALTER TABLE ONLY public.calendar_events
 
 
 --
--- TOC entry 3498 (class 2606 OID 24603)
+-- TOC entry 3510 (class 2606 OID 24603)
 -- Name: client_orders client_orders_order_number_unique; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2846,7 +2990,7 @@ ALTER TABLE ONLY public.client_orders
 
 
 --
--- TOC entry 3500 (class 2606 OID 24601)
+-- TOC entry 3512 (class 2606 OID 24601)
 -- Name: client_orders client_orders_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2855,7 +2999,7 @@ ALTER TABLE ONLY public.client_orders
 
 
 --
--- TOC entry 3502 (class 2606 OID 24612)
+-- TOC entry 3514 (class 2606 OID 24612)
 -- Name: command_items command_items_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2864,7 +3008,7 @@ ALTER TABLE ONLY public.command_items
 
 
 --
--- TOC entry 3504 (class 2606 OID 24627)
+-- TOC entry 3516 (class 2606 OID 24627)
 -- Name: commands commands_command_number_unique; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2873,7 +3017,7 @@ ALTER TABLE ONLY public.commands
 
 
 --
--- TOC entry 3506 (class 2606 OID 24625)
+-- TOC entry 3518 (class 2606 OID 24625)
 -- Name: commands commands_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2882,7 +3026,7 @@ ALTER TABLE ONLY public.commands
 
 
 --
--- TOC entry 3545 (class 2606 OID 57540)
+-- TOC entry 3557 (class 2606 OID 57540)
 -- Name: customer_orders customer_orders_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2891,7 +3035,7 @@ ALTER TABLE ONLY public.customer_orders
 
 
 --
--- TOC entry 3508 (class 2606 OID 24638)
+-- TOC entry 3520 (class 2606 OID 24638)
 -- Name: customers customers_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2900,7 +3044,7 @@ ALTER TABLE ONLY public.customers
 
 
 --
--- TOC entry 3587 (class 2606 OID 2342922)
+-- TOC entry 3599 (class 2606 OID 2342922)
 -- Name: dashboard_messages dashboard_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2909,7 +3053,7 @@ ALTER TABLE ONLY public.dashboard_messages
 
 
 --
--- TOC entry 3573 (class 2606 OID 819224)
+-- TOC entry 3585 (class 2606 OID 819224)
 -- Name: database_backups database_backups_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2918,7 +3062,7 @@ ALTER TABLE ONLY public.database_backups
 
 
 --
--- TOC entry 3564 (class 2606 OID 73746)
+-- TOC entry 3576 (class 2606 OID 73746)
 -- Name: deliveries deliveries_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2927,7 +3071,7 @@ ALTER TABLE ONLY public.deliveries
 
 
 --
--- TOC entry 3510 (class 2606 OID 24662)
+-- TOC entry 3522 (class 2606 OID 24662)
 -- Name: delivery_items delivery_items_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2936,7 +3080,7 @@ ALTER TABLE ONLY public.delivery_items
 
 
 --
--- TOC entry 3547 (class 2606 OID 57550)
+-- TOC entry 3559 (class 2606 OID 57550)
 -- Name: dlc_products dlc_products_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2945,7 +3089,7 @@ ALTER TABLE ONLY public.dlc_products
 
 
 --
--- TOC entry 3533 (class 2606 OID 57462)
+-- TOC entry 3545 (class 2606 OID 57462)
 -- Name: groups groups_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2954,7 +3098,7 @@ ALTER TABLE ONLY public.groups
 
 
 --
--- TOC entry 3583 (class 2606 OID 2310156)
+-- TOC entry 3595 (class 2606 OID 2310156)
 -- Name: invoice_verification_cache invoice_verification_cache_cache_key_key; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2963,7 +3107,7 @@ ALTER TABLE ONLY public.invoice_verification_cache
 
 
 --
--- TOC entry 3585 (class 2606 OID 2310154)
+-- TOC entry 3597 (class 2606 OID 2310154)
 -- Name: invoice_verification_cache invoice_verification_cache_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2972,7 +3116,7 @@ ALTER TABLE ONLY public.invoice_verification_cache
 
 
 --
--- TOC entry 3577 (class 2606 OID 2285579)
+-- TOC entry 3589 (class 2606 OID 2285579)
 -- Name: invoice_verifications invoice_verifications_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2981,7 +3125,7 @@ ALTER TABLE ONLY public.invoice_verifications
 
 
 --
--- TOC entry 3512 (class 2606 OID 24690)
+-- TOC entry 3524 (class 2606 OID 24690)
 -- Name: invoices invoices_invoice_number_unique; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2990,7 +3134,7 @@ ALTER TABLE ONLY public.invoices
 
 
 --
--- TOC entry 3514 (class 2606 OID 24688)
+-- TOC entry 3526 (class 2606 OID 24688)
 -- Name: invoices invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -2999,7 +3143,7 @@ ALTER TABLE ONLY public.invoices
 
 
 --
--- TOC entry 3592 (class 2606 OID 2359305)
+-- TOC entry 3604 (class 2606 OID 2359305)
 -- Name: migrations migrations_filename_key; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3008,7 +3152,7 @@ ALTER TABLE ONLY public.migrations
 
 
 --
--- TOC entry 3594 (class 2606 OID 2359303)
+-- TOC entry 3606 (class 2606 OID 2359303)
 -- Name: migrations migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3017,7 +3161,7 @@ ALTER TABLE ONLY public.migrations
 
 
 --
--- TOC entry 3535 (class 2606 OID 57474)
+-- TOC entry 3547 (class 2606 OID 57474)
 -- Name: nocodb_config nocodb_config_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3026,7 +3170,7 @@ ALTER TABLE ONLY public.nocodb_config
 
 
 --
--- TOC entry 3539 (class 2606 OID 57498)
+-- TOC entry 3551 (class 2606 OID 57498)
 -- Name: orders orders_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3035,7 +3179,7 @@ ALTER TABLE ONLY public.orders
 
 
 --
--- TOC entry 3556 (class 2606 OID 57592)
+-- TOC entry 3568 (class 2606 OID 57592)
 -- Name: permissions permissions_name_key; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3044,7 +3188,7 @@ ALTER TABLE ONLY public.permissions
 
 
 --
--- TOC entry 3558 (class 2606 OID 57590)
+-- TOC entry 3570 (class 2606 OID 57590)
 -- Name: permissions permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3053,7 +3197,7 @@ ALTER TABLE ONLY public.permissions
 
 
 --
--- TOC entry 3541 (class 2606 OID 57522)
+-- TOC entry 3553 (class 2606 OID 57522)
 -- Name: publicities publicities_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3062,7 +3206,7 @@ ALTER TABLE ONLY public.publicities
 
 
 --
--- TOC entry 3543 (class 2606 OID 57524)
+-- TOC entry 3555 (class 2606 OID 57524)
 -- Name: publicities publicities_pub_number_key; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3071,7 +3215,7 @@ ALTER TABLE ONLY public.publicities
 
 
 --
--- TOC entry 3562 (class 2606 OID 57620)
+-- TOC entry 3574 (class 2606 OID 57620)
 -- Name: publicity_participations publicity_participations_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3080,7 +3224,7 @@ ALTER TABLE ONLY public.publicity_participations
 
 
 --
--- TOC entry 3606 (class 2606 OID 2375691)
+-- TOC entry 3618 (class 2606 OID 2375691)
 -- Name: reconciliation_comments reconciliation_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3089,7 +3233,7 @@ ALTER TABLE ONLY public.reconciliation_comments
 
 
 --
--- TOC entry 3560 (class 2606 OID 57614)
+-- TOC entry 3572 (class 2606 OID 57614)
 -- Name: role_permissions role_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3098,7 +3242,7 @@ ALTER TABLE ONLY public.role_permissions
 
 
 --
--- TOC entry 3552 (class 2606 OID 57579)
+-- TOC entry 3564 (class 2606 OID 57579)
 -- Name: roles roles_name_key; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3107,7 +3251,7 @@ ALTER TABLE ONLY public.roles
 
 
 --
--- TOC entry 3554 (class 2606 OID 57577)
+-- TOC entry 3566 (class 2606 OID 57577)
 -- Name: roles roles_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3116,7 +3260,7 @@ ALTER TABLE ONLY public.roles
 
 
 --
--- TOC entry 3516 (class 2606 OID 24703)
+-- TOC entry 3528 (class 2606 OID 24703)
 -- Name: sav_tickets sav_tickets_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3125,7 +3269,7 @@ ALTER TABLE ONLY public.sav_tickets
 
 
 --
--- TOC entry 3518 (class 2606 OID 24705)
+-- TOC entry 3530 (class 2606 OID 24705)
 -- Name: sav_tickets sav_tickets_ticket_number_unique; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3134,7 +3278,7 @@ ALTER TABLE ONLY public.sav_tickets
 
 
 --
--- TOC entry 3523 (class 2606 OID 32776)
+-- TOC entry 3535 (class 2606 OID 32776)
 -- Name: session session_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3143,7 +3287,7 @@ ALTER TABLE ONLY public.session
 
 
 --
--- TOC entry 3526 (class 2606 OID 57433)
+-- TOC entry 3538 (class 2606 OID 57433)
 -- Name: sessions sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3152,7 +3296,7 @@ ALTER TABLE ONLY public.sessions
 
 
 --
--- TOC entry 3520 (class 2606 OID 24717)
+-- TOC entry 3532 (class 2606 OID 24717)
 -- Name: stores stores_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3161,7 +3305,7 @@ ALTER TABLE ONLY public.stores
 
 
 --
--- TOC entry 3537 (class 2606 OID 57486)
+-- TOC entry 3549 (class 2606 OID 57486)
 -- Name: suppliers suppliers_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3170,7 +3314,7 @@ ALTER TABLE ONLY public.suppliers
 
 
 --
--- TOC entry 3550 (class 2606 OID 57563)
+-- TOC entry 3562 (class 2606 OID 57563)
 -- Name: tasks tasks_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3179,7 +3323,7 @@ ALTER TABLE ONLY public.tasks
 
 
 --
--- TOC entry 3571 (class 2606 OID 720930)
+-- TOC entry 3583 (class 2606 OID 720930)
 -- Name: user_groups user_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3188,7 +3332,7 @@ ALTER TABLE ONLY public.user_groups
 
 
 --
--- TOC entry 3569 (class 2606 OID 720917)
+-- TOC entry 3581 (class 2606 OID 720917)
 -- Name: user_roles user_roles_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3197,7 +3341,7 @@ ALTER TABLE ONLY public.user_roles
 
 
 --
--- TOC entry 3529 (class 2606 OID 57445)
+-- TOC entry 3541 (class 2606 OID 57445)
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3206,7 +3350,7 @@ ALTER TABLE ONLY public.users
 
 
 --
--- TOC entry 3531 (class 2606 OID 57447)
+-- TOC entry 3543 (class 2606 OID 57447)
 -- Name: users users_username_key; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3215,7 +3359,16 @@ ALTER TABLE ONLY public.users
 
 
 --
--- TOC entry 3602 (class 2606 OID 2359345)
+-- TOC entry 3620 (class 2606 OID 2383886)
+-- Name: weather_settings weather_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
+--
+
+ALTER TABLE ONLY public.weather_settings
+    ADD CONSTRAINT weather_settings_pkey PRIMARY KEY (id);
+
+
+--
+-- TOC entry 3614 (class 2606 OID 2359345)
 -- Name: webhook_bap_config webhook_bap_config_pkey; Type: CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3224,7 +3377,7 @@ ALTER TABLE ONLY public.webhook_bap_config
 
 
 --
--- TOC entry 3521 (class 1259 OID 32777)
+-- TOC entry 3533 (class 1259 OID 32777)
 -- Name: IDX_session_expire; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3232,7 +3385,7 @@ CREATE INDEX "IDX_session_expire" ON public.session USING btree (expire);
 
 
 --
--- TOC entry 3597 (class 1259 OID 2359331)
+-- TOC entry 3609 (class 1259 OID 2359331)
 -- Name: idx_announcements_author_id; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3240,7 +3393,7 @@ CREATE INDEX idx_announcements_author_id ON public.announcements USING btree (au
 
 
 --
--- TOC entry 3598 (class 1259 OID 2359330)
+-- TOC entry 3610 (class 1259 OID 2359330)
 -- Name: idx_announcements_created_at; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3248,7 +3401,7 @@ CREATE INDEX idx_announcements_created_at ON public.announcements USING btree (c
 
 
 --
--- TOC entry 3599 (class 1259 OID 2359332)
+-- TOC entry 3611 (class 1259 OID 2359332)
 -- Name: idx_announcements_group_id; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3256,7 +3409,7 @@ CREATE INDEX idx_announcements_group_id ON public.announcements USING btree (gro
 
 
 --
--- TOC entry 3600 (class 1259 OID 2359329)
+-- TOC entry 3612 (class 1259 OID 2359329)
 -- Name: idx_announcements_priority; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3264,7 +3417,7 @@ CREATE INDEX idx_announcements_priority ON public.announcements USING btree (pri
 
 
 --
--- TOC entry 3578 (class 1259 OID 2310157)
+-- TOC entry 3590 (class 1259 OID 2310157)
 -- Name: idx_cache_key; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3272,7 +3425,7 @@ CREATE INDEX idx_cache_key ON public.invoice_verification_cache USING btree (cac
 
 
 --
--- TOC entry 3588 (class 1259 OID 2342923)
+-- TOC entry 3600 (class 1259 OID 2342923)
 -- Name: idx_dashboard_messages_created_at; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3280,7 +3433,7 @@ CREATE INDEX idx_dashboard_messages_created_at ON public.dashboard_messages USIN
 
 
 --
--- TOC entry 3589 (class 1259 OID 2342925)
+-- TOC entry 3601 (class 1259 OID 2342925)
 -- Name: idx_dashboard_messages_created_by; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3288,7 +3441,7 @@ CREATE INDEX idx_dashboard_messages_created_by ON public.dashboard_messages USIN
 
 
 --
--- TOC entry 3590 (class 1259 OID 2342924)
+-- TOC entry 3602 (class 1259 OID 2342924)
 -- Name: idx_dashboard_messages_store_id; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3296,7 +3449,7 @@ CREATE INDEX idx_dashboard_messages_store_id ON public.dashboard_messages USING 
 
 
 --
--- TOC entry 3579 (class 1259 OID 2310160)
+-- TOC entry 3591 (class 1259 OID 2310160)
 -- Name: idx_delivery_id; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3304,7 +3457,7 @@ CREATE INDEX idx_delivery_id ON public.invoice_verification_cache USING btree (d
 
 
 --
--- TOC entry 3548 (class 1259 OID 2334721)
+-- TOC entry 3560 (class 1259 OID 2334721)
 -- Name: idx_dlc_products_stock_epuise; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3312,7 +3465,7 @@ CREATE INDEX idx_dlc_products_stock_epuise ON public.dlc_products USING btree (s
 
 
 --
--- TOC entry 3580 (class 1259 OID 2310159)
+-- TOC entry 3592 (class 1259 OID 2310159)
 -- Name: idx_expires_at; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3320,7 +3473,7 @@ CREATE INDEX idx_expires_at ON public.invoice_verification_cache USING btree (ex
 
 
 --
--- TOC entry 3581 (class 1259 OID 2310158)
+-- TOC entry 3593 (class 1259 OID 2310158)
 -- Name: idx_group_invoice; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3328,7 +3481,7 @@ CREATE INDEX idx_group_invoice ON public.invoice_verification_cache USING btree 
 
 
 --
--- TOC entry 3524 (class 1259 OID 57434)
+-- TOC entry 3536 (class 1259 OID 57434)
 -- Name: idx_session_expire; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3336,7 +3489,7 @@ CREATE INDEX idx_session_expire ON public.sessions USING btree (expire);
 
 
 --
--- TOC entry 3565 (class 1259 OID 720946)
+-- TOC entry 3577 (class 1259 OID 720946)
 -- Name: idx_user_roles_assigned_by; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3344,7 +3497,7 @@ CREATE INDEX idx_user_roles_assigned_by ON public.user_roles USING btree (assign
 
 
 --
--- TOC entry 3566 (class 1259 OID 720945)
+-- TOC entry 3578 (class 1259 OID 720945)
 -- Name: idx_user_roles_role_id; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3352,7 +3505,7 @@ CREATE INDEX idx_user_roles_role_id ON public.user_roles USING btree (role_id);
 
 
 --
--- TOC entry 3567 (class 1259 OID 720944)
+-- TOC entry 3579 (class 1259 OID 720944)
 -- Name: idx_user_roles_user_id; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3360,7 +3513,7 @@ CREATE INDEX idx_user_roles_user_id ON public.user_roles USING btree (user_id);
 
 
 --
--- TOC entry 3574 (class 1259 OID 2285590)
+-- TOC entry 3586 (class 1259 OID 2285590)
 -- Name: invoice_verifications_delivery_idx; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3368,7 +3521,7 @@ CREATE INDEX invoice_verifications_delivery_idx ON public.invoice_verifications 
 
 
 --
--- TOC entry 3575 (class 1259 OID 2285591)
+-- TOC entry 3587 (class 1259 OID 2285591)
 -- Name: invoice_verifications_invoice_ref_idx; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3376,7 +3529,7 @@ CREATE INDEX invoice_verifications_invoice_ref_idx ON public.invoice_verificatio
 
 
 --
--- TOC entry 3527 (class 1259 OID 319488)
+-- TOC entry 3539 (class 1259 OID 319488)
 -- Name: users_email_unique; Type: INDEX; Schema: public; Owner: neondb_owner
 --
 
@@ -3384,7 +3537,7 @@ CREATE UNIQUE INDEX users_email_unique ON public.users USING btree (email) WHERE
 
 
 --
--- TOC entry 3612 (class 2606 OID 2359319)
+-- TOC entry 3626 (class 2606 OID 2359319)
 -- Name: announcements announcements_author_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3393,7 +3546,7 @@ ALTER TABLE ONLY public.announcements
 
 
 --
--- TOC entry 3613 (class 2606 OID 2359324)
+-- TOC entry 3627 (class 2606 OID 2359324)
 -- Name: announcements announcements_group_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3402,7 +3555,7 @@ ALTER TABLE ONLY public.announcements
 
 
 --
--- TOC entry 3610 (class 2606 OID 2285580)
+-- TOC entry 3624 (class 2606 OID 2285580)
 -- Name: invoice_verifications invoice_verifications_delivery_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3411,7 +3564,7 @@ ALTER TABLE ONLY public.invoice_verifications
 
 
 --
--- TOC entry 3611 (class 2606 OID 2285585)
+-- TOC entry 3625 (class 2606 OID 2285585)
 -- Name: invoice_verifications invoice_verifications_group_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3420,7 +3573,7 @@ ALTER TABLE ONLY public.invoice_verifications
 
 
 --
--- TOC entry 3614 (class 2606 OID 2375697)
+-- TOC entry 3628 (class 2606 OID 2375697)
 -- Name: reconciliation_comments reconciliation_comments_author_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3429,7 +3582,7 @@ ALTER TABLE ONLY public.reconciliation_comments
 
 
 --
--- TOC entry 3615 (class 2606 OID 2375692)
+-- TOC entry 3629 (class 2606 OID 2375692)
 -- Name: reconciliation_comments reconciliation_comments_delivery_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3438,7 +3591,7 @@ ALTER TABLE ONLY public.reconciliation_comments
 
 
 --
--- TOC entry 3616 (class 2606 OID 2375702)
+-- TOC entry 3630 (class 2606 OID 2375702)
 -- Name: reconciliation_comments reconciliation_comments_group_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3447,7 +3600,7 @@ ALTER TABLE ONLY public.reconciliation_comments
 
 
 --
--- TOC entry 3607 (class 2606 OID 2269185)
+-- TOC entry 3621 (class 2606 OID 2269185)
 -- Name: tasks tasks_completed_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3456,7 +3609,7 @@ ALTER TABLE ONLY public.tasks
 
 
 --
--- TOC entry 3609 (class 2606 OID 720931)
+-- TOC entry 3623 (class 2606 OID 720931)
 -- Name: user_groups user_groups_group_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3465,7 +3618,7 @@ ALTER TABLE ONLY public.user_groups
 
 
 --
--- TOC entry 3608 (class 2606 OID 720918)
+-- TOC entry 3622 (class 2606 OID 720918)
 -- Name: user_roles user_roles_role_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: neondb_owner
 --
 
@@ -3474,8 +3627,8 @@ ALTER TABLE ONLY public.user_roles
 
 
 --
--- TOC entry 3830 (class 0 OID 0)
--- Dependencies: 3829
+-- TOC entry 3846 (class 0 OID 0)
+-- Dependencies: 3845
 -- Name: DATABASE neondb; Type: ACL; Schema: -; Owner: neondb_owner
 --
 
@@ -3483,7 +3636,7 @@ GRANT ALL ON DATABASE neondb TO neon_superuser;
 
 
 --
--- TOC entry 2206 (class 826 OID 16392)
+-- TOC entry 2211 (class 826 OID 16392)
 -- Name: DEFAULT PRIVILEGES FOR SEQUENCES; Type: DEFAULT ACL; Schema: public; Owner: cloud_admin
 --
 
@@ -3491,14 +3644,14 @@ ALTER DEFAULT PRIVILEGES FOR ROLE cloud_admin IN SCHEMA public GRANT ALL ON SEQU
 
 
 --
--- TOC entry 2205 (class 826 OID 16391)
+-- TOC entry 2210 (class 826 OID 16391)
 -- Name: DEFAULT PRIVILEGES FOR TABLES; Type: DEFAULT ACL; Schema: public; Owner: cloud_admin
 --
 
 ALTER DEFAULT PRIVILEGES FOR ROLE cloud_admin IN SCHEMA public GRANT ALL ON TABLES TO neon_superuser WITH GRANT OPTION;
 
 
--- Completed on 2025-09-11 05:59:58 UTC
+-- Completed on 2025-09-23 08:42:41 UTC
 
 --
 -- PostgreSQL database dump complete

--- a/client/src/components/modals/CreateDeliveryModal.tsx
+++ b/client/src/components/modals/CreateDeliveryModal.tsx
@@ -61,10 +61,16 @@ export default function CreateDeliveryModal({
     queryKey: ['/api/orders'],
   });
 
-  // Filtrer les commandes par fournisseur sélectionné - montrer toutes les commandes non livrées
-  const availableOrders = allOrders.filter(order => 
-    formData.supplierId ? (order.supplierId === parseInt(formData.supplierId) && order.status !== 'delivered') : false
-  );
+  // Filtrer les commandes par fournisseur ET magasin sélectionnés - montrer toutes les commandes non livrées
+  const availableOrders = allOrders.filter(order => {
+    if (!formData.supplierId || !formData.groupId) return false;
+    
+    return (
+      order.supplierId === parseInt(formData.supplierId) &&
+      order.groupId === parseInt(formData.groupId) &&
+      order.status !== 'delivered'
+    );
+  });
 
   // Auto-sélectionner le magasin selon les règles
   useEffect(() => {
@@ -123,6 +129,13 @@ export default function CreateDeliveryModal({
       setFormData(prev => ({ ...prev, orderId: "" }));
     }
   }, [formData.supplierId]);
+
+  // Réinitialiser la commande sélectionnée quand on change de magasin
+  useEffect(() => {
+    if (formData.groupId) {
+      setFormData(prev => ({ ...prev, orderId: "" }));
+    }
+  }, [formData.groupId]);
 
   const createDeliveryMutation = useMutation({
     mutationFn: async (data: any) => {


### PR DESCRIPTION
Correctly filter available orders in the Create Delivery modal to only display orders associated with the selected supplier and store, and reset the selected order when the store changes.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 1e4433b5-47ab-464c-b663-fea2e53367dd
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1957c339-2757-4d1f-8e92-e9f71a1ce58e/1e4433b5-47ab-464c-b663-fea2e53367dd/ah44t7Y